### PR TITLE
feat: upgrade base CDCS to MDCS 3.21.0 and add /upgrade-base-cdcs command

### DIFF
--- a/.claude/commands/upgrade-base-cdcs.md
+++ b/.claude/commands/upgrade-base-cdcs.md
@@ -1,0 +1,300 @@
+---
+argument-hint: <new-cdcs-version>
+description: Upgrade the base CDCS/MDCS version (core_*_app packages) and update all related files, including checking if our overridden files need updates
+---
+
+# Upgrade Base CDCS Version
+
+Automates upgrading NexusLIMS-CDCS to a new upstream MDCS base version.
+
+## Step 0: Determine Target Version
+
+If the user provided a version argument (e.g. `/upgrade-base-cdcs 3.22.0`), use it as `TARGET_VERSION`.
+
+If no argument was provided, fetch the latest MDCS release:
+```bash
+gh release list --repo usnistgov/MDCS --limit 5
+```
+Present the options and ask the user to confirm which version to upgrade to before proceeding.
+
+Also determine the PREVIOUS MDCS version that is currently installed:
+```bash
+grep 'core_main_app' pyproject.toml | head -1
+```
+Extract the current `2.N.*` version to determine `PREV_MDCS_VERSION = 3.N.0` (e.g. `2.20.*` → `3.20.0`).
+
+---
+
+## Step 1: Gather Current State
+
+Run these in parallel to understand the starting point:
+
+```bash
+# Current version and core package pin
+grep -E "^version|core_main_app" pyproject.toml | head -5
+
+# Current branch
+git branch --show-current
+
+# Working tree state (must be clean before starting)
+git status --short
+```
+
+**Gate:** If the working tree is not clean, stop and tell the user to commit or stash changes first.
+
+---
+
+## Step 2: Determine New Core Package Version
+
+MDCS version maps to core package version like this:
+- MDCS `3.21.0` uses `core_*_app==2.21.*`
+- MDCS `3.22.0` uses `core_*_app==2.22.*`
+- General rule: MDCS `3.N.x` uses `core_*_app==2.N.*`
+
+Derive `CORE_VERSION` from `TARGET_VERSION`:
+- Extract the minor version number `N` from `3.N.x`
+- Set `CORE_VERSION = 2.N.*`
+
+Verify the packages exist by checking the MDCS `requirements.core.txt` at the target tag:
+```bash
+curl -s "https://raw.githubusercontent.com/usnistgov/MDCS/${TARGET_VERSION}/requirements.core.txt"
+```
+
+If this returns a 404 or empty content, the tag does not exist yet -- stop and tell the user.
+
+---
+
+## Step 3: Read Release Notes for ALL Skipped Versions
+
+If we are jumping across multiple MDCS versions (e.g. 3.20.0 → 3.22.0), we must read the
+release notes for every intermediate version too, not just the target. Changes accumulate.
+
+First, list all MDCS releases between PREV and TARGET:
+```bash
+gh release list --repo usnistgov/MDCS --limit 20 --json tagName,publishedAt \
+  --jq '.[] | select(.tagName | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tagName'
+```
+
+For each version greater than PREV_MDCS_VERSION and less than or equal to TARGET_VERSION, fetch its release notes:
+```bash
+gh release view <VERSION> --repo usnistgov/MDCS --json body,name --jq '.body'
+```
+
+Read and summarise ALL release notes. Note any mentions of:
+- New settings added
+- Deprecated or removed settings
+- Breaking API changes
+- UI changes (new templates, changed CSS)
+- New or removed dependencies
+
+---
+
+## Step 4: Dynamically Determine Which Files We Override
+
+Before diffing, build the current lists of overridden files from the actual repo state.
+
+### 4a. Files we copy from the MDCS upstream repo
+
+Get the full file tree of the MDCS upstream repo at TARGET_VERSION:
+```bash
+curl -s "https://api.github.com/repos/usnistgov/MDCS/git/trees/${TARGET_VERSION}?recursive=1" \
+  | python3 -c "import sys,json; [print(i['path']) for i in json.load(sys.stdin).get('tree',[]) if i['type']=='blob']" \
+  | sort > /tmp/mdcs-upstream-files.txt
+```
+
+Get the list of tracked files in our local repo (excluding .venv, .superpowers, generated files):
+```bash
+git ls-files | grep -v "^\.venv\|^\.superpowers\|^static\.prod\|^uv\.lock\|^\.gitignore" | sort > /tmp/our-files.txt
+```
+
+The intersection is the set of files that exist in both repos -- these are the files we may have overridden and that we need to check for upstream changes:
+```bash
+comm -12 /tmp/mdcs-upstream-files.txt /tmp/our-files.txt
+```
+
+### 4b. Templates we override from core_*_app packages
+
+Scan the `nexuslims_overrides/templates/` directory to find all overridden templates:
+```bash
+find nexuslims_overrides/templates/ -type f -name "*.html" | sort
+```
+
+For each template path like `nexuslims_overrides/templates/<app_name>/<rest>`, the upstream template lives at `<rest>` in the `<app_name>` GitHub repository. Build the list of (package, template_path) pairs dynamically from this scan.
+
+---
+
+## Step 5: Check Upstream Changes
+
+### 5a. Changed files in the MDCS repo itself
+
+For each file identified in Step 4a, diff it between PREV and TARGET:
+```bash
+for f in <file_list_from_4a>; do
+  old=$(curl -s "https://raw.githubusercontent.com/usnistgov/MDCS/${PREV_MDCS_VERSION}/$f")
+  new=$(curl -s "https://raw.githubusercontent.com/usnistgov/MDCS/${TARGET_VERSION}/$f")
+  if [ "$old" != "$new" ]; then
+    echo "CHANGED: $f"
+    diff <(echo "$old") <(echo "$new")
+  fi
+done
+```
+
+For each CHANGED file:
+- Determine if the change is **cosmetic** (docstring reformatting, whitespace only) or **functional** (new logic, new setting, new CSS rule, etc.)
+- For **functional** changes: compare the upstream diff against our local version. If we don't already have the change, apply it -- but preserve our intentional customisations.
+- For **cosmetic** changes: skip (no action needed unless we want uniform formatting).
+
+### 5b. Changed templates in core_*_app packages
+
+For each (package, template_path) pair from Step 4b:
+
+```bash
+OLD_CORE="${PREV_MDCS_VERSION/#3./2.}.0"   # e.g. 3.20.0 -> 2.20.0
+NEW_CORE="${TARGET_VERSION/#3./2.}.0"       # e.g. 3.21.0 -> 2.21.0
+
+old=$(curl -s "https://raw.githubusercontent.com/usnistgov/<PACKAGE>/${OLD_CORE}/<TEMPLATE_PATH>")
+new=$(curl -s "https://raw.githubusercontent.com/usnistgov/<PACKAGE>/${NEW_CORE}/<TEMPLATE_PATH>")
+diff <(echo "$old") <(echo "$new")
+```
+
+For each CHANGED template, compare the upstream diff against our local override in
+`nexuslims_overrides/templates/`. Determine whether:
+- Our override already incorporates the upstream change (no action needed)
+- Our override needs to be updated to stay compatible
+- The upstream change conflicts with our customisation (flag for user review)
+
+### 5c. New settings in core_main_app
+
+Diff `core_main_app/settings.md` between old and new versions:
+```bash
+OLD_CORE="${PREV_MDCS_VERSION/#3./2.}.0"
+NEW_CORE="${TARGET_VERSION/#3./2.}.0"
+diff \
+  <(curl -s "https://raw.githubusercontent.com/usnistgov/core_main_app/${OLD_CORE}/settings.md") \
+  <(curl -s "https://raw.githubusercontent.com/usnistgov/core_main_app/${NEW_CORE}/settings.md")
+```
+
+For each new setting found:
+- Add it to `mdcs/core_settings.py` using the `os.getenv("SETTING_NAME", default)` pattern
+- Use the same default value as upstream
+- Include a one-line docstring from the upstream `settings.md`
+
+---
+
+## Step 6: Create Feature Branch
+
+```bash
+git checkout -b issue-{ISSUE_NUMBER}-upgrade-base-cdcs-${TARGET_VERSION}
+```
+
+If there is no issue number, use:
+```bash
+git checkout -b upgrade-base-cdcs-${TARGET_VERSION}
+```
+
+---
+
+## Step 7: Apply Changes
+
+### 7a. Update `pyproject.toml`
+
+1. Bump the `version` field to `${TARGET_VERSION}+nx0`
+2. Update the comment line: `# CDCS/MDCS core packages - all pinned to ${CORE_VERSION} for compatibility`
+3. Update all `core_*_app` pins from old version to `${CORE_VERSION}` (use the list from `requirements.core.txt` as the authoritative list -- it may add or remove packages between versions)
+
+### 7b. Update `mdcs/core_settings.py`
+
+1. Update `PROJECT_VERSION` default from old version to `${TARGET_VERSION}`
+2. Apply any new or removed settings identified in Steps 3 and 5c
+
+### 7c. Apply upstream file changes (from Step 5)
+
+For each functional change found in Step 5a or 5b, apply the equivalent change to our local file.
+Do NOT blindly apply all upstream changes -- our files intentionally diverge from upstream in places.
+Apply only the lines that add new behavior or fix bugs, while preserving our customisations.
+
+### 7d. Regenerate the lockfile
+
+```bash
+uv lock --upgrade
+```
+
+Review the output and note which packages were updated (for the commit message and changelog).
+
+---
+
+## Step 8: Create Changelog Fragment
+
+Create `docs/changes/{ISSUE_NUMBER}.misc.md`:
+
+```
+Upgraded the underlying CDCS/MDCS base from version PREV_MDCS_VERSION to TARGET_VERSION, bringing in the latest upstream improvements including [brief summary from all release notes].
+```
+
+If there is no issue number, skip this step.
+
+---
+
+## Step 9: Run Tests
+
+```bash
+uv run python runtests.py
+```
+
+Fix any failures before proceeding. Common upgrade issues:
+- New required settings missing from `core_settings.py`
+- Deprecated API usage removed upstream
+- Migration conflicts
+
+---
+
+## Step 10: Lint
+
+```bash
+uv tool run ruff format .
+uv tool run ruff check .
+```
+
+Fix any violations introduced by your changes. Do not add `# noqa` suppressions without user
+confirmation. Pre-existing violations (present on `main`) that are not introduced by this upgrade
+do not need to be fixed; they may be cleaned up in a separate commit if desired.
+
+---
+
+## Step 11: Commit
+
+Stage and commit the upgrade-specific files first:
+```bash
+git add pyproject.toml uv.lock mdcs/core_settings.py docs/changes/
+# plus any other files specifically changed by the upgrade (e.g. static/css/main.css)
+git commit -m "feat: upgrade base CDCS to MDCS ${TARGET_VERSION} (core packages ${CORE_VERSION})
+
+- Update all core_*_app packages from OLD_CORE_VERSION to ${CORE_VERSION} in pyproject.toml
+- Bump project version to ${TARGET_VERSION}+nx0
+- Update PROJECT_VERSION default to ${TARGET_VERSION}
+- [List any new settings added]
+- [List any upstream file changes applied]
+- [Note any other significant changes from the lockfile upgrade]
+
+Closes #{ISSUE_NUMBER}"
+```
+
+If ruff format changed additional files, commit those separately:
+```bash
+git add -A
+git commit -m "style: apply ruff format to all Python source files"
+```
+
+---
+
+## Step 12: Summary
+
+Report:
+- Branch name created
+- All intermediate versions whose release notes were reviewed
+- All packages updated (old → new versions from `uv lock` output)
+- Any upstream file changes applied (and whether they were functional or cosmetic)
+- Any template override changes needed
+- New settings added to `core_settings.py` (if any)
+- Test results
+- Next step: run `/datasophos:pr` to open a pull request

--- a/attr-maps/attr-map.py
+++ b/attr-maps/attr-map.py
@@ -1,5 +1,4 @@
-""" SAML attribute mapping
-"""
+"""SAML attribute mapping"""
 
 from core_main_app.utils.saml2.utils import load_attribute_map_from_env
 

--- a/config/settings/demo_settings.py
+++ b/config/settings/demo_settings.py
@@ -17,10 +17,10 @@ IS_PUBLIC_DEMO = True
 DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
 
 # No email sending in the demo
-EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
 
 # Whitelist of usernames that can be selected via ?demo_as=<username>
-DEMO_USERNAMES = ['admin', 'readonly_user', 'project_lead']
+DEMO_USERNAMES = ["admin", "readonly_user", "project_lead"]
 
 # Additional instrument color mappings for demo datasets
 NX_INSTRUMENT_COLOR_MAPPINGS = {
@@ -36,22 +36,24 @@ NX_INSTRUMENT_COLOR_MAPPINGS = {
 if DEBUG:
     TEMPLATES[0] = {  # noqa: F821
         **TEMPLATES[0],  # noqa: F821
-        'APP_DIRS': False,  # must be False when 'loaders' is explicitly set
-        'OPTIONS': {
-            **TEMPLATES[0]['OPTIONS'],  # noqa: F821
-            'loaders': [
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
+        "APP_DIRS": False,  # must be False when 'loaders' is explicitly set
+        "OPTIONS": {
+            **TEMPLATES[0]["OPTIONS"],  # noqa: F821
+            "loaders": [
+                "django.template.loaders.filesystem.Loader",
+                "django.template.loaders.app_directories.Loader",
             ],
         },
     }
 
 # Auto-login middleware - insert after AuthenticationMiddleware
-_demo_middleware = 'nexuslims_overrides.middleware.DemoAutoLoginMiddleware'
+_demo_middleware = "nexuslims_overrides.middleware.DemoAutoLoginMiddleware"
 MIDDLEWARE = list(MIDDLEWARE)  # noqa: F821 - may be a tuple from base settings
 if _demo_middleware not in MIDDLEWARE:
     try:
-        _auth_idx = MIDDLEWARE.index('django.contrib.auth.middleware.AuthenticationMiddleware')
+        _auth_idx = MIDDLEWARE.index(
+            "django.contrib.auth.middleware.AuthenticationMiddleware"
+        )
         MIDDLEWARE.insert(_auth_idx + 1, _demo_middleware)
     except ValueError:
         MIDDLEWARE.append(_demo_middleware)
@@ -62,12 +64,12 @@ NX_CUSTOM_MENU_LINKS = [
         "title": "Datasophos",
         "url": "https://datasophos.co/",
         "icon": "globe",
-        "iconClass": "fas"
+        "iconClass": "fas",
     },
     {
         "title": "Github Repository",
         "url": "https://github.com/datasophos/NexusLIMS-CDCS",
         "icon": "github",
-        "iconClass": "fab"
-    }
+        "iconClass": "fab",
+    },
 ]

--- a/config/settings/dev_settings.py
+++ b/config/settings/dev_settings.py
@@ -10,28 +10,28 @@ DEBUG = True
 
 # Development-specific logging
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
         },
     },
-    'root': {
-        'handlers': ['console'],
-        'level': 'INFO',
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
     },
-    'loggers': {
-        'django': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            'propagate': False,
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
         },
     },
 }
 
 # Allow all hosts in development (restricted by Docker network)
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 # Development-specific CORS settings (if needed)
 # CORS_ALLOW_ALL_ORIGINS = True

--- a/config/settings/prod_settings.py
+++ b/config/settings/prod_settings.py
@@ -72,7 +72,7 @@ CACHES = {
         "LOCATION": f"redis://:{REDIS_PASSWORD}@{REDIS_HOST}:{REDIS_PORT}/0",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        }
+        },
     }
 }
 

--- a/deployment/scripts/backup_cdcs.py
+++ b/deployment/scripts/backup_cdcs.py
@@ -22,24 +22,29 @@ from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from urllib.parse import urljoin
-import hashlib
 
 # Django setup for access to models
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"),
+)
 sys.path.insert(0, "/srv/nexuslims")
 import django
+
 django.setup()
 
 from django.contrib.auth import get_user_model
 from django.core import serializers
 from django.test import RequestFactory
 from core_main_app.components.template import api as template_api
-from core_main_app.components.template_version_manager import api as template_version_manager_api
+from core_main_app.components.template_version_manager import (
+    api as template_version_manager_api,
+)
 from core_main_app.components.xsl_transformation import api as xsl_transformation_api
-from core_main_app.components.template_xsl_rendering import api as template_xsl_rendering_api
-from core_main_app.components.data import api as data_api
+from core_main_app.components.template_xsl_rendering import (
+    api as template_xsl_rendering_api,
+)
 from core_main_app.components.data.models import Data
-from core_main_app.components.workspace.models import Workspace
 
 
 class CDCSBackup:
@@ -71,7 +76,9 @@ class CDCSBackup:
         self.backup_dir.mkdir(parents=True, exist_ok=True)
 
         # API configuration
-        self.base_url = base_url or os.getenv("SERVER_URI", "https://nexuslims-dev.localhost")
+        self.base_url = base_url or os.getenv(
+            "SERVER_URI", "https://nexuslims-dev.localhost"
+        )
         self.username = username or "admin"
         self.password = password or "admin"
         self.session = requests.Session()
@@ -85,7 +92,7 @@ class CDCSBackup:
             "blobs": 0,
             "users": 0,
             "xslt": 0,
-            "queries": 0
+            "queries": 0,
         }
 
         # Get superuser for Django ORM operations
@@ -102,7 +109,7 @@ class CDCSBackup:
         self.request = factory.get("/")
         self.request.user = self.superuser
 
-        print(f"Backup initialized:")
+        print("Backup initialized:")
         print(f"  Directory: {self.backup_dir}")
         print(f"  Base URL: {self.base_url}")
         print(f"  User: {self.superuser.username}")
@@ -119,9 +126,13 @@ class CDCSBackup:
 
         # Check for production backup mount
         backups_host_path = os.getenv("NX_CDCS_BACKUPS_HOST_PATH")
-        if backups_host_path and container_path_str.startswith("/srv/nexuslims/backups"):
+        if backups_host_path and container_path_str.startswith(
+            "/srv/nexuslims/backups"
+        ):
             # Production: specific backup directory mount
-            relative = container_path_str.replace("/srv/nexuslims/backups", "").lstrip("/")
+            relative = container_path_str.replace("/srv/nexuslims/backups", "").lstrip(
+                "/"
+            )
             host_path = Path(backups_host_path) / relative
             return host_path
 
@@ -152,7 +163,11 @@ class CDCSBackup:
 
         # Get all global template version managers using Django ORM
         try:
-            template_managers = template_version_manager_api.get_global_version_managers(request=self.request)
+            template_managers = (
+                template_version_manager_api.get_global_version_managers(
+                    request=self.request
+                )
+            )
         except Exception as e:
             print(f"  ⚠️  Could not retrieve templates: {e}")
             return
@@ -167,7 +182,7 @@ class CDCSBackup:
                 continue
 
             # Create directory for this template
-            safe_title = re.sub(r'[^\w\s-]', '', title).strip().replace(' ', '_')
+            safe_title = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "_")
             template_dir = schemas_dir / f"{safe_title}_{template_id}"
             template_dir.mkdir(exist_ok=True)
 
@@ -188,8 +203,7 @@ class CDCSBackup:
                     "version_manager_id": str(tm.id),
                 }
                 (template_dir / "metadata.json").write_text(
-                    json.dumps(metadata, indent=2),
-                    encoding="utf-8"
+                    json.dumps(metadata, indent=2), encoding="utf-8"
                 )
 
                 self.stats["templates"] += 1
@@ -212,18 +226,24 @@ class CDCSBackup:
 
             # Handle list_detail_xslt - could be a list, array, or ManyRelatedManager
             list_detail_xslt_ids = []
-            if hasattr(rendering, 'list_detail_xslt') and rendering.list_detail_xslt:
+            if hasattr(rendering, "list_detail_xslt") and rendering.list_detail_xslt:
                 # Check if it's a manager (has .all() method) or a list/array
-                if hasattr(rendering.list_detail_xslt, 'all'):
+                if hasattr(rendering.list_detail_xslt, "all"):
                     # It's a ManyRelatedManager
-                    list_detail_xslt_ids = [str(xslt.id) for xslt in rendering.list_detail_xslt.all()]
+                    list_detail_xslt_ids = [
+                        str(xslt.id) for xslt in rendering.list_detail_xslt.all()
+                    ]
                 elif isinstance(rendering.list_detail_xslt, (list, tuple)):
                     # It's already a list/tuple of IDs
-                    list_detail_xslt_ids = [str(xid) for xid in rendering.list_detail_xslt]
+                    list_detail_xslt_ids = [
+                        str(xid) for xid in rendering.list_detail_xslt
+                    ]
                 else:
                     # It might be a single value or array field
                     try:
-                        list_detail_xslt_ids = [str(xid) for xid in rendering.list_detail_xslt]
+                        list_detail_xslt_ids = [
+                            str(xid) for xid in rendering.list_detail_xslt
+                        ]
                     except TypeError:
                         list_detail_xslt_ids = []
 
@@ -231,17 +251,27 @@ class CDCSBackup:
             association = {
                 "template_id": str(template_id),
                 "rendering_id": str(rendering.id),
-                "list_xslt_id": str(rendering.list_xslt.id) if rendering.list_xslt else None,
-                "list_xslt_name": rendering.list_xslt.name if rendering.list_xslt else None,
-                "default_detail_xslt_id": str(rendering.default_detail_xslt.id) if rendering.default_detail_xslt else None,
-                "default_detail_xslt_name": rendering.default_detail_xslt.name if rendering.default_detail_xslt else None,
+                "list_xslt_id": str(rendering.list_xslt.id)
+                if rendering.list_xslt
+                else None,
+                "list_xslt_name": rendering.list_xslt.name
+                if rendering.list_xslt
+                else None,
+                "default_detail_xslt_id": str(rendering.default_detail_xslt.id)
+                if rendering.default_detail_xslt
+                else None,
+                "default_detail_xslt_name": rendering.default_detail_xslt.name
+                if rendering.default_detail_xslt
+                else None,
                 "list_detail_xslt_ids": list_detail_xslt_ids,
             }
 
             # Save association metadata
             association_path = template_dir / "xslt_association.json"
-            association_path.write_text(json.dumps(association, indent=2), encoding="utf-8")
-            print(f"    → Saved XSLT associations")
+            association_path.write_text(
+                json.dumps(association, indent=2), encoding="utf-8"
+            )
+            print("    → Saved XSLT associations")
 
         except Exception as e:
             # No XSLT rendering for this template (not an error, but log it)
@@ -265,7 +295,9 @@ class CDCSBackup:
                     self.backup_single_record_from_orm(record, files_dir, blobs_dir)
                     total_records += 1
                 except Exception as e:
-                    print(f"    ✗ Failed to backup record {getattr(record, 'title', 'unknown')}: {e}")
+                    print(
+                        f"    ✗ Failed to backup record {getattr(record, 'title', 'unknown')}: {e}"
+                    )
 
             if total_records > 0:
                 print(f"    → Saved {total_records} records")
@@ -281,7 +313,7 @@ class CDCSBackup:
         xml_content = record.get("xml_content", "")
 
         # Create safe filename
-        safe_title = re.sub(r'[^\w\s-]', '', title).strip().replace(' ', '_')[:100]
+        safe_title = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "_")[:100]
 
         # Handle duplicate titles
         counter = 1
@@ -302,7 +334,7 @@ class CDCSBackup:
         xml_content = getattr(record, "xml_content", "")
 
         # Create safe filename
-        safe_title = re.sub(r'[^\w\s-]', '', title).strip().replace(' ', '_')[:100]
+        safe_title = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "_")[:100]
 
         # Handle duplicate titles
         counter = 1
@@ -318,20 +350,20 @@ class CDCSBackup:
         metadata = {
             "id": str(record.id),
             "title": title,
-            "user_id": str(record.user_id) if hasattr(record, 'user_id') else None,
+            "user_id": str(record.user_id) if hasattr(record, "user_id") else None,
             "workspace_id": None,
             "workspace_title": None,
             "is_global_workspace": False,
         }
 
         # Capture workspace information
-        if hasattr(record, 'workspace') and record.workspace:
+        if hasattr(record, "workspace") and record.workspace:
             metadata["workspace_id"] = str(record.workspace.id)
-            metadata["workspace_title"] = getattr(record.workspace, 'title', None)
+            metadata["workspace_title"] = getattr(record.workspace, "title", None)
             metadata["is_global_workspace"] = record.workspace.is_global
 
         # Save metadata alongside XML
-        metadata_path = xml_path.with_suffix('.xml.metadata.json')
+        metadata_path = xml_path.with_suffix(".xml.metadata.json")
         metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
         # Extract and backup blobs
@@ -341,7 +373,7 @@ class CDCSBackup:
         """Extract blob references from XML and backup the files."""
         # Find blob references in XML
         # Pattern: <preview>http://127.0.0.1/pid/rest/local/cdcs/<blob-id></preview>
-        blob_pattern = r'http://127\.0\.0\.1/pid/rest/local/cdcs/([^<]+)'
+        blob_pattern = r"http://127\.0\.0\.1/pid/rest/local/cdcs/([^<]+)"
         blob_ids = re.findall(blob_pattern, xml_content)
 
         for blob_id in blob_ids:
@@ -359,7 +391,7 @@ class CDCSBackup:
 
                 self.stats["blobs"] += 1
 
-            except Exception as e:
+            except Exception:
                 # Blob might not exist or might not be accessible
                 pass
 
@@ -373,10 +405,7 @@ class CDCSBackup:
         # Serialize users to JSON
         # NOTE: We must preserve primary keys so user_id references in records remain valid
         users_json = serializers.serialize(
-            "json",
-            users,
-            indent=2,
-            use_natural_foreign_keys=True
+            "json", users, indent=2, use_natural_foreign_keys=True
         )
 
         users_path = self.backup_dir / "users.json"
@@ -408,10 +437,12 @@ class CDCSBackup:
                 metadata = {
                     "id": str(xslt.id),
                     "name": xslt.name,
-                    "filename": xslt.filename
+                    "filename": xslt.filename,
                 }
                 metadata_path = xslt_dir / f"{filename}.metadata.json"
-                metadata_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+                metadata_path.write_text(
+                    json.dumps(metadata, indent=2), encoding="utf-8"
+                )
 
                 self.stats["xslt"] += 1
                 print(f"  ✓ {filename}")
@@ -429,7 +460,7 @@ class CDCSBackup:
         try:
             # Try to use Django ORM to get persistent queries
             from core_explore_keyword_app.components.persistent_query_keyword import (
-                api as persistent_query_api
+                api as persistent_query_api,
             )
 
             queries = persistent_query_api.get_all(self.superuser)
@@ -437,24 +468,30 @@ class CDCSBackup:
             for query in queries:
                 # Handle None query names
                 query_name = getattr(query, "name", None) or f"query_{query.id}"
-                safe_name = re.sub(r'[^\w\s-]', '', query_name).strip().replace(' ', '_')
+                safe_name = (
+                    re.sub(r"[^\w\s-]", "", query_name).strip().replace(" ", "_")
+                )
 
                 # Serialize query to dict
                 query_data = {
                     "id": str(query.id),
                     "name": query.name,
                     "content": getattr(query, "content", ""),
-                    "user_id": str(query.user_id) if hasattr(query, "user_id") else None,
+                    "user_id": str(query.user_id)
+                    if hasattr(query, "user_id")
+                    else None,
                 }
 
                 query_path = queries_dir / f"{safe_name}.json"
-                query_path.write_text(json.dumps(query_data, indent=2), encoding="utf-8")
+                query_path.write_text(
+                    json.dumps(query_data, indent=2), encoding="utf-8"
+                )
 
                 self.stats["queries"] += 1
                 print(f"  ✓ {query_name}")
 
         except ImportError:
-            print(f"  ⚠️  core_explore_keyword_app not available, skipping queries")
+            print("  ⚠️  core_explore_keyword_app not available, skipping queries")
         except Exception as e:
             print(f"  ⚠️  Could not backup queries: {e}")
 
@@ -464,14 +501,17 @@ class CDCSBackup:
 
         # Create restore script
         restore_script = self.backup_dir / "restore.sh"
-        restore_script.write_text(f"""#!/bin/bash
+        restore_script.write_text(
+            f"""#!/bin/bash
 # Auto-generated restore script
 # Created: {datetime.now().isoformat()}
 
 BACKUP_DIR="{self.backup_dir}"
 
 python /srv/scripts/restore_cdcs.py --all "$BACKUP_DIR"
-""", encoding="utf-8")
+""",
+            encoding="utf-8",
+        )
 
         restore_script.chmod(0o755)
         print(f"  ✓ Created {restore_script}")
@@ -551,6 +591,7 @@ python /srv/scripts/restore_cdcs.py --all "$BACKUP_DIR"
         except Exception as e:
             print(f"✗ Backup failed: {e}")
             import traceback
+
             traceback.print_exc()
             return 1
 
@@ -570,7 +611,7 @@ if __name__ == "__main__":
         backup_dir=args.dir,
         base_url=args.url,
         username=args.username,
-        password=args.password
+        password=args.password,
     )
 
     sys.exit(backup.run())

--- a/deployment/scripts/check_record_links.py
+++ b/deployment/scripts/check_record_links.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from urllib.parse import urljoin, urlparse
 
 import requests
 import urllib3
@@ -26,6 +25,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # ---------------------------------------------------------------------------
 # Link extraction via Playwright
 # ---------------------------------------------------------------------------
+
 
 def get_page_links(url: str, timeout_ms: int = 30000) -> dict[str, list[str]]:
     """Render the page with Playwright and extract resource URLs by category."""
@@ -85,6 +85,7 @@ def get_page_links(url: str, timeout_ms: int = 30000) -> dict[str, list[str]]:
 # Link checking
 # ---------------------------------------------------------------------------
 
+
 def check_url(url: str, session: requests.Session) -> tuple[int | None, str]:
     """Return (status_code, error_message). status_code is None on connection error."""
     try:
@@ -98,7 +99,9 @@ def check_url(url: str, session: requests.Session) -> tuple[int | None, str]:
         return None, str(e)
 
 
-def check_links(links: dict[str, list[str]]) -> dict[str, list[tuple[str, int | None, str]]]:
+def check_links(
+    links: dict[str, list[str]],
+) -> dict[str, list[tuple[str, int | None, str]]]:
     """Check all links and return failures grouped by category."""
     session = requests.Session()
     failures: dict[str, list[tuple[str, int | None, str]]] = {}
@@ -119,13 +122,16 @@ def check_links(links: dict[str, list[str]]) -> dict[str, list[tuple[str, int | 
 # Reporting
 # ---------------------------------------------------------------------------
 
-def report(page_url: str, links: dict[str, list[str]], failures: dict[str, list[tuple]]) -> bool:
+
+def report(
+    page_url: str, links: dict[str, list[str]], failures: dict[str, list[tuple]]
+) -> bool:
     """Print results. Returns True if all links OK."""
     total = sum(len(v) for v in links.values())
     total_fail = sum(len(v) for v in failures.values())
     ok = total - total_fail
 
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print(f"URL: {page_url}")
     print(f"  previews:  {len(links['previews'])}")
     print(f"  json:      {len(links['json'])}")
@@ -149,6 +155,7 @@ def report(page_url: str, links: dict[str, list[str]], failures: dict[str, list[
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def build_record_urls(base: str, ids: list[int]) -> list[str]:
     base = base.rstrip("/")
@@ -182,11 +189,25 @@ def fetch_all_record_ids(base: str) -> list[int]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Check CDCS record resource links for 404s")
-    parser.add_argument("url", help="Full record URL (e.g. https://host/data?id=16) or base URL with --all/--ids")
-    parser.add_argument("--all", action="store_true", help="Check all records (url should be base URL)")
-    parser.add_argument("--ids", help="Comma-separated record IDs to check (url should be base URL)")
-    parser.add_argument("--timeout", type=int, default=30, help="Page load timeout in seconds (default 30)")
+    parser = argparse.ArgumentParser(
+        description="Check CDCS record resource links for 404s"
+    )
+    parser.add_argument(
+        "url",
+        help="Full record URL (e.g. https://host/data?id=16) or base URL with --all/--ids",
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="Check all records (url should be base URL)"
+    )
+    parser.add_argument(
+        "--ids", help="Comma-separated record IDs to check (url should be base URL)"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Page load timeout in seconds (default 30)",
+    )
     args = parser.parse_args()
 
     if args.all:

--- a/deployment/scripts/generate_demo_records.py
+++ b/deployment/scripts/generate_demo_records.py
@@ -21,7 +21,7 @@ import shutil
 import sys
 import xml.etree.ElementTree as ET
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 try:
@@ -629,7 +629,9 @@ def build_xml(
                 }.get(ext, "Unknown")
 
             # Build relative path for location
-            rel = f.relative_to(f.parents[len(f.parts) - f.parts.index(folder_name) - 1])
+            rel = f.relative_to(
+                f.parents[len(f.parts) - f.parts.index(folder_name) - 1]
+            )
             location = "/" + str(rel).replace(os.sep, "/")
 
             ds = _el(act, "dataset")
@@ -644,16 +646,22 @@ def build_xml(
             # Thumbnail (must come after description per XSD)
             # Try both naming conventions: stem.thumb.png and full-name.thumb.png
             thumb = next(
-                (p for p in [
-                    f.parent / (f.stem + ".thumb.png"),
-                    f.parent / (f.name + ".thumb.png"),
-                ] if p.exists()),
+                (
+                    p
+                    for p in [
+                        f.parent / (f.stem + ".thumb.png"),
+                        f.parent / (f.name + ".thumb.png"),
+                    ]
+                    if p.exists()
+                ),
                 None,
             )
             if thumb is not None:
                 thumb_rel = "/" + str(
                     thumb.relative_to(
-                        thumb.parents[len(thumb.parts) - thumb.parts.index(folder_name) - 1]
+                        thumb.parents[
+                            len(thumb.parts) - thumb.parts.index(folder_name) - 1
+                        ]
                     )
                 ).replace(os.sep, "/")
                 _el(ds, "preview", thumb_rel)
@@ -705,10 +713,14 @@ def populate_demo_data(
         # nx-data: JSON + thumbnail
         json_src = data_file.parent / (data_file.name + ".json")
         thumb_src = next(
-            (p for p in [
-                data_file.parent / (data_file.stem + ".thumb.png"),
-                data_file.parent / (data_file.name + ".thumb.png"),
-            ] if p.exists()),
+            (
+                p
+                for p in [
+                    data_file.parent / (data_file.stem + ".thumb.png"),
+                    data_file.parent / (data_file.name + ".thumb.png"),
+                ]
+                if p.exists()
+            ),
             None,
         )
 
@@ -741,7 +753,7 @@ def process_folder(
     schema: etree.XMLSchema | None,
 ) -> bool:
     folder_name = folder.name
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Processing: {folder_name}")
 
     # Find .webloc file
@@ -939,7 +951,7 @@ def main():
             traceback.print_exc()
             failed += 1
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Done: {success} succeeded, {failed} failed/skipped")
     print(f"XML records: {args.output_records}")
     print(f"Demo data:   {args.output_demo_data}")

--- a/deployment/scripts/init_environment.py
+++ b/deployment/scripts/init_environment.py
@@ -39,7 +39,10 @@ from pathlib import Path
 
 # Set up Django environment
 # Use DJANGO_SETTINGS_MODULE from environment, or fall back to config.settings.dev_settings
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"),
+)
 sys.path.insert(0, "/srv/nexuslims")
 
 import django
@@ -48,6 +51,7 @@ django.setup()
 
 # Suppress verbose logging from core_main_app
 import logging
+
 logging.getLogger("core_main_app").setLevel(logging.ERROR)
 
 
@@ -78,6 +82,7 @@ def is_production():
     Production = DEBUG is False.
     """
     from django.conf import settings
+
     return not settings.DEBUG
 
 
@@ -88,13 +93,15 @@ def is_development():
     Development = DEBUG is True.
     """
     from django.conf import settings
+
     return settings.DEBUG
 
 
 def is_demo():
     """Check if running in public demo mode."""
     from django.conf import settings
-    return getattr(settings, 'IS_PUBLIC_DEMO', False)
+
+    return getattr(settings, "IS_PUBLIC_DEMO", False)
 
 
 def check_migrations():
@@ -146,9 +153,11 @@ def get_or_create_superuser():
 
     # Production: Use Django's createsuperuser command (interactive)
     if is_production():
-        log_info("No superuser found. Creating superuser (you will be prompted for credentials)...")
+        log_info(
+            "No superuser found. Creating superuser (you will be prompted for credentials)..."
+        )
         try:
-            call_command('createsuperuser')
+            call_command("createsuperuser")
             # Fetch the newly created superuser
             superuser = User.objects.filter(is_superuser=True).first()
             if superuser:
@@ -166,9 +175,7 @@ def get_or_create_superuser():
     log_info("Creating default superuser (username: admin, password: admin)...")
     try:
         superuser = User.objects.create_superuser(
-            username="admin",
-            email="admin@localhost",
-            password="admin"
+            username="admin", email="admin@localhost", password="admin"
         )
         log_success(f"Superuser created: {superuser.username}")
         return superuser
@@ -200,9 +207,7 @@ def get_or_create_regular_user():
     log_info("Creating default regular user (username: user, password: user)...")
     try:
         regular_user = User.objects.create_user(
-            username="user",
-            email="user@localhost",
-            password="user"
+            username="user", email="user@localhost", password="user"
         )
         log_success(f"Regular user created: {regular_user.username}")
         return regular_user
@@ -272,9 +277,13 @@ def get_or_create_demo_users():
     )
     if data_perms.exists():
         lead.user_permissions.set(data_perms)
-        log_success(f"Granted project_lead permissions: {', '.join(p.codename for p in data_perms)}")
+        log_success(
+            f"Granted project_lead permissions: {', '.join(p.codename for p in data_perms)}"
+        )
     else:
-        log_warning("core_main_app data permissions not found yet - project_lead will have default perms")
+        log_warning(
+            "core_main_app data permissions not found yet - project_lead will have default perms"
+        )
 
 
 def get_request_for_user(user):
@@ -303,18 +312,24 @@ def grant_anonymous_explore_permission():
 
     try:
         # Check if permission is already granted
-        anonymous_group = Group.objects.filter(name='anonymous').first()
+        anonymous_group = Group.objects.filter(name="anonymous").first()
         if not anonymous_group:
             log_info("Anonymous group not found - will be created by migration")
             return
 
-        permission = Permission.objects.filter(codename='access_explore_keyword').first()
+        permission = Permission.objects.filter(
+            codename="access_explore_keyword"
+        ).first()
         if not permission:
             log_info("Explore permission not found yet - will be handled by migration")
             return
 
-        if anonymous_group.permissions.filter(codename='access_explore_keyword').exists():
-            log_success("Anonymous group already has explore permission (from migration)")
+        if anonymous_group.permissions.filter(
+            codename="access_explore_keyword"
+        ).exists():
+            log_success(
+                "Anonymous group already has explore permission (from migration)"
+            )
         else:
             # Grant it if not already there (fallback for pre-migration deployments)
             anonymous_group.permissions.add(permission)
@@ -366,8 +381,10 @@ def upload_schema(request, schema_path=None):
 
     # Check if template already exists
     try:
-        existing_tvm = template_version_manager_api.get_active_global_version_manager_by_title(
-            template_title
+        existing_tvm = (
+            template_version_manager_api.get_active_global_version_manager_by_title(
+                template_title
+            )
         )
         log_success(f"Template '{template_title}' already exists")
         return existing_tvm
@@ -394,9 +411,7 @@ def upload_schema(request, schema_path=None):
 
         # Insert requires (template_version_manager, template, request)
         template_vm = template_version_manager_api.insert(
-            template_vm,
-            template=template,
-            request=request
+            template_vm, template=template, request=request
         )
 
         # Link template back to version manager and save
@@ -406,12 +421,14 @@ def upload_schema(request, schema_path=None):
         log_success(f"Template '{template_title}' created (ID: {template.id})")
         return template_vm
 
-    except IntegrityError as e:
+    except IntegrityError:
         # Template already exists (race condition or duplicate)
         log_info("Template already exists, fetching existing template...")
         try:
-            existing_tvm = template_version_manager_api.get_active_global_version_manager_by_title(
-                template_title, request=request
+            existing_tvm = (
+                template_version_manager_api.get_active_global_version_manager_by_title(
+                    template_title, request=request
+                )
             )
             log_success(f"Template '{template_title}' found")
             return existing_tvm
@@ -436,6 +453,7 @@ def upload_schema(request, schema_path=None):
             # Unexpected error - show details
             log_error(f"Failed to create template: {e}")
             import traceback
+
             traceback.print_exc()
             # Don't raise - let the script continue
             return None
@@ -456,7 +474,7 @@ def upload_example_records(request, template_vm):
     record_paths = [
         Path("/srv/test-data/example_record.xml"),
         Path("/srv/test-data/example_record_large.xml"),
-        Path("/srv/test-data/example_record_multisample.xml")
+        Path("/srv/test-data/example_record_multisample.xml"),
     ]
     uploaded = []
     for record_path in record_paths:
@@ -471,7 +489,9 @@ def upload_example_records(request, template_vm):
             # Check if this record already exists
             existing_record = Data.objects.filter(title=title).first()
             if existing_record:
-                log_success(f"Example record '{title}' already exists (ID: {existing_record.id})")
+                log_success(
+                    f"Example record '{title}' already exists (ID: {existing_record.id})"
+                )
                 uploaded.append(existing_record)
                 continue
 
@@ -481,13 +501,11 @@ def upload_example_records(request, template_vm):
 
             # Get the current template
             from core_main_app.components.template import api as template_api
+
             template = template_api.get_by_id(template_vm.current, request=request)
 
             # Create the data record
-            data_record = Data(
-                template=template,
-                title=title
-            )
+            data_record = Data(template=template, title=title)
 
             # Set the content and user
             # NOTE: Use 'content' not 'xml_content' so convert_to_dict() works
@@ -497,7 +515,9 @@ def upload_example_records(request, template_vm):
             # Save the data record (this will populate dict_content via convert_to_dict())
             data_record = data_api.upsert(data_record, request=request)
 
-            log_success(f"Example record uploaded (ID: {data_record.id}, title: {data_record.title})")
+            log_success(
+                f"Example record uploaded (ID: {data_record.id}, title: {data_record.title})"
+            )
 
             # Get or create the global public workspace
             try:
@@ -515,11 +535,12 @@ def upload_example_records(request, template_vm):
             data_record.workspace = public_workspace
             data_record = data_api.upsert(data_record, request=request)
             uploaded.append(data_record)
-            log_success(f"Example record assigned to global public workspace")
+            log_success("Example record assigned to global public workspace")
 
         except Exception as e:
             log_error(f"Failed to upload example record: {e}")
             import traceback
+
             traceback.print_exc()
             # Don't raise - let the script continue
             return None
@@ -540,9 +561,6 @@ def upload_xslt_stylesheets(request, template_vm):
     )
     from core_main_app.components.template_xsl_rendering import (
         api as template_xsl_rendering_api,
-    )
-    from core_main_app.components.template_xsl_rendering.models import (
-        TemplateXslRendering,
     )
 
     # Get the current template
@@ -580,11 +598,10 @@ def upload_xslt_stylesheets(request, template_vm):
         # Get URLs from environment variables
         dataset_base_url = os.getenv(
             "XSLT_DATASET_BASE_URL",
-            "https://files.nexuslims-dev.localhost/instrument-data"
+            "https://files.nexuslims-dev.localhost/instrument-data",
         )
         preview_base_url = os.getenv(
-            "XSLT_PREVIEW_BASE_URL",
-            "https://files.nexuslims-dev.localhost/data"
+            "XSLT_PREVIEW_BASE_URL", "https://files.nexuslims-dev.localhost/data"
         )
 
         log_info(f"Patching URLs in {stylesheet_name}...")
@@ -594,11 +611,11 @@ def upload_xslt_stylesheets(request, template_vm):
         # Perform replacements
         stylesheet_content = stylesheet_content.replace(
             '<xsl:variable name="datasetBaseUrl">https://CHANGE.THIS.VALUE</xsl:variable>',
-            f'<xsl:variable name="datasetBaseUrl">{dataset_base_url}</xsl:variable>'
+            f'<xsl:variable name="datasetBaseUrl">{dataset_base_url}</xsl:variable>',
         )
         stylesheet_content = stylesheet_content.replace(
             '<xsl:variable name="previewBaseUrl">https://CHANGE.THIS.VALUE</xsl:variable>',
-            f'<xsl:variable name="previewBaseUrl">{preview_base_url}</xsl:variable>'
+            f'<xsl:variable name="previewBaseUrl">{preview_base_url}</xsl:variable>',
         )
 
         # Verify replacements
@@ -634,13 +651,15 @@ def upload_xslt_stylesheets(request, template_vm):
                 log_success("XSLT rendering already configured")
             except Exception:
                 # Create new rendering configuration using the API
-                list_detail_xslt_ids = [xslt_map["list"].id] if "list" in xslt_map else []
+                list_detail_xslt_ids = (
+                    [xslt_map["list"].id] if "list" in xslt_map else []
+                )
 
                 rendering = template_xsl_rendering_api.upsert(
                     template=template,
                     list_xslt=xslt_map.get("list"),
                     default_detail_xslt=xslt_map.get("detail"),
-                    list_detail_xslt=list_detail_xslt_ids
+                    list_detail_xslt=list_detail_xslt_ids,
                 )
                 log_success(f"XSLT rendering configured (ID: {rendering.id})")
         except Exception as e:
@@ -655,7 +674,8 @@ def compile_translations():
 
     try:
         from django.core.management import call_command
-        call_command('compilemessages', verbosity=0)
+
+        call_command("compilemessages", verbosity=0)
         log_success("Translations compiled successfully")
     except Exception as e:
         log_error(f"Failed to compile translations: {e}")
@@ -683,18 +703,22 @@ def setup_api_tokens(superuser):
 
     # Determine which token setting to use based on environment
     if is_development():
-        token_value = getattr(settings, 'NX_DEV_API_TOKEN', None)
+        token_value = getattr(settings, "NX_DEV_API_TOKEN", None)
         token_name = "development"
     else:
-        token_value = getattr(settings, 'NX_ADMIN_API_TOKEN', None)
+        token_value = getattr(settings, "NX_ADMIN_API_TOKEN", None)
         token_name = "production admin"
 
     if not token_value:
         log_info(f"No {token_name} API token configured - skipping token setup")
         if is_development():
-            log_info("To configure: Set NX_DEV_API_TOKEN in config/settings/dev_settings.py")
+            log_info(
+                "To configure: Set NX_DEV_API_TOKEN in config/settings/dev_settings.py"
+            )
         else:
-            log_info("To configure: Set NX_ADMIN_API_TOKEN environment variable in .env")
+            log_info(
+                "To configure: Set NX_ADMIN_API_TOKEN environment variable in .env"
+            )
         return
 
     # Check if token already exists for this user
@@ -703,12 +727,16 @@ def setup_api_tokens(superuser):
 
         # If token key matches, we're done
         if existing_token.key == token_value:
-            log_success(f"{token_name.capitalize()} API token already exists for user '{superuser.username}'")
+            log_success(
+                f"{token_name.capitalize()} API token already exists for user '{superuser.username}'"
+            )
             return
 
         # Token exists but key is different - delete and recreate
         existing_token.delete()
-        log_info(f"Removed existing token with different key for user '{superuser.username}'")
+        log_info(
+            f"Removed existing token with different key for user '{superuser.username}'"
+        )
     except Token.DoesNotExist:
         # No existing token, will create new one
         pass
@@ -735,7 +763,7 @@ def setup_terms_of_use():
 
         # If any non-empty record exists, leave it alone so admins can customise freely
         pages = WebPage.objects.filter(type=t)
-        if pages.filter(content__regex=r'\S').exists():
+        if pages.filter(content__regex=r"\S").exists():
             log_success("Terms of Use page already exists")
             return
 
@@ -830,25 +858,32 @@ def load_exporters():
             log_info(f"Exporters already loaded ({len(existing_exporters)} found)")
 
             # Remove BLOB exporter if it exists (NexusLIMS doesn't use blobs)
-            blob_exporters = [exp for exp in existing_exporters if exp.name.upper() == 'BLOB']
+            blob_exporters = [
+                exp for exp in existing_exporters if exp.name.upper() == "BLOB"
+            ]
             if blob_exporters:
                 for blob_exp in blob_exporters:
                     blob_exp.delete()
                     log_info(f"Removed BLOB exporter (ID: {blob_exp.id})")
 
                 remaining = exporter_api.get_all()
-                log_success(f"Exporters configured: {', '.join(exp.name for exp in remaining)}")
+                log_success(
+                    f"Exporters configured: {', '.join(exp.name for exp in remaining)}"
+                )
             else:
-                log_success(f"Exporters configured: {', '.join(exp.name for exp in existing_exporters)}")
+                log_success(
+                    f"Exporters configured: {', '.join(exp.name for exp in existing_exporters)}"
+                )
             return
 
         # Load exporters using Django management command
         from django.core.management import call_command
-        call_command('loadexporters')
+
+        call_command("loadexporters")
 
         # Remove BLOB exporter (NexusLIMS doesn't use blobs)
         all_exporters = exporter_api.get_all()
-        blob_exporters = [exp for exp in all_exporters if exp.name.upper() == 'BLOB']
+        blob_exporters = [exp for exp in all_exporters if exp.name.upper() == "BLOB"]
         if blob_exporters:
             for blob_exp in blob_exporters:
                 blob_exp.delete()
@@ -856,7 +891,9 @@ def load_exporters():
 
         # Verify final state
         exporters = exporter_api.get_all()
-        log_success(f"Loaded {len(exporters)} exporters: {', '.join(exp.name for exp in exporters)}")
+        log_success(
+            f"Loaded {len(exporters)} exporters: {', '.join(exp.name for exp in exporters)}"
+        )
 
     except Exception as e:
         log_error(f"Failed to load exporters: {e}")
@@ -868,11 +905,13 @@ def main():
     import argparse
 
     # Parse command line arguments for schema path (production use)
-    parser = argparse.ArgumentParser(description="Initialize NexusLIMS-CDCS environment")
+    parser = argparse.ArgumentParser(
+        description="Initialize NexusLIMS-CDCS environment"
+    )
     parser.add_argument(
         "--schema",
         help="Path to schema file (e.g., /tmp/nexus-experiment.xsd)",
-        default=None
+        default=None,
     )
     args = parser.parse_args()
 
@@ -903,8 +942,11 @@ def main():
         # Must be after get_or_create_demo_users() so the demo admin is available.
         if superuser is None:
             from django.contrib.auth import get_user_model
+
             User = get_user_model()
-            superuser = User.objects.filter(is_superuser=True).first() or User.objects.first()
+            superuser = (
+                User.objects.filter(is_superuser=True).first() or User.objects.first()
+            )
 
         # Create request object for API calls (may be None if no users exist)
         request = get_request_for_user(superuser) if superuser else None
@@ -945,12 +987,18 @@ def main():
                 print(f"  Schema: {template_vm.title}")
             print()
             print("Next steps:")
-            print(f"  1. Access the site: {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}")
+            print(
+                f"  1. Access the site: {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}"
+            )
             if superuser:
-                print(f"  2. Login with your superuser credentials")
-            print(f"  3. Begin uploading data records via the NexusLIMS backend")
-            print(f"  4. Explore data: {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}/explore/keyword/")
-            print(f"  5. As an admin, you can manually add records at {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}/curate/")
+                print("  2. Login with your superuser credentials")
+            print("  3. Begin uploading data records via the NexusLIMS backend")
+            print(
+                f"  4. Explore data: {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}/explore/keyword/"
+            )
+            print(
+                f"  5. As an admin, you can manually add records at {os.getenv('SERVER_URI', 'https://nexuslims.example.com')}/curate/"
+            )
         else:
             if superuser:
                 print(f"  Superuser: {superuser.username}")
@@ -966,13 +1014,16 @@ def main():
                 print("  - Login with: user / user (regular user for testing)")
             print("  - View example record: https://nexuslims-dev.localhost/data?id=1")
             print("  - Explore data: https://nexuslims-dev.localhost/explore/keyword/")
-            print("  - Start uploading data using the Nexus Experiment Schema or at https://nexuslims-dev.localhost/curate")
+            print(
+                "  - Start uploading data using the Nexus Experiment Schema or at https://nexuslims-dev.localhost/curate"
+            )
 
         print("=" * 70)
 
     except Exception as e:
         log_error(f"Initialization failed: {e}")
         import traceback
+
         traceback.print_exc()
         log_warning("Continuing despite errors...")
 

--- a/deployment/scripts/restore_cdcs.py
+++ b/deployment/scripts/restore_cdcs.py
@@ -16,36 +16,40 @@ import json
 import argparse
 import logging
 from pathlib import Path
-from datetime import datetime
+
 
 # Filter specific noisy log messages
 class MessageFilter(logging.Filter):
     def filter(self, record):
         noisy_messages = [
-            'SSL_CERTIFICATES_DIR',
-            'Registered signals',
-            'No request or session id is None',
+            "SSL_CERTIFICATES_DIR",
+            "Registered signals",
+            "No request or session id is None",
         ]
         return not any(msg in record.getMessage() for msg in noisy_messages)
 
+
 # Apply filter to root logger and common CDCS loggers
-for logger_name in ['', 'core_main_app', 'django']:
+for logger_name in ["", "core_main_app", "django"]:
     logger = logging.getLogger(logger_name)
     logger.addFilter(MessageFilter())
+
 
 # Also filter stdout/stderr for print statements
 class FilteredWriter:
     def __init__(self, stream):
         self.stream = stream
         self.noisy_patterns = [
-            'SSL_CERTIFICATES_DIR',
-            'Registered signals',
-            'No request or session id is None',
+            "SSL_CERTIFICATES_DIR",
+            "Registered signals",
+            "No request or session id is None",
         ]
 
     def write(self, text):
         # Allow empty strings (newlines) to pass through, filter only lines with noisy patterns
-        if not text.strip() or not any(pattern in text for pattern in self.noisy_patterns):
+        if not text.strip() or not any(
+            pattern in text for pattern in self.noisy_patterns
+        ):
             self.stream.write(text)
 
     def flush(self):
@@ -54,23 +58,32 @@ class FilteredWriter:
     def __getattr__(self, name):
         return getattr(self.stream, name)
 
+
 # Wrap stdout and stderr
 sys.stdout = FilteredWriter(sys.stdout)
 sys.stderr = FilteredWriter(sys.stderr)
 
 # Django setup
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"),
+)
 sys.path.insert(0, "/srv/nexuslims")
 import django
+
 django.setup()
 
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory
 from django.core.management import call_command
 from core_main_app.components.template import api as template_api
-from core_main_app.components.template_version_manager import api as template_version_manager_api
+from core_main_app.components.template_version_manager import (
+    api as template_version_manager_api,
+)
 from core_main_app.components.xsl_transformation import api as xsl_transformation_api
-from core_main_app.components.template_xsl_rendering import api as template_xsl_rendering_api
+from core_main_app.components.template_xsl_rendering import (
+    api as template_xsl_rendering_api,
+)
 from core_main_app.components.data import api as data_api
 from core_main_app.components.workspace.models import Workspace
 
@@ -185,7 +198,9 @@ def restore_xslt(xslt_dir):
                 log_success(f"Updated stylesheet: {stylesheet_name}")
             except Exception:
                 # Create new stylesheet
-                from core_main_app.components.xsl_transformation.models import XslTransformation
+                from core_main_app.components.xsl_transformation.models import (
+                    XslTransformation,
+                )
 
                 xslt = XslTransformation()
                 xslt.name = stylesheet_name
@@ -212,7 +227,9 @@ def restore_template_xslt_association(template_dir, template_id, request):
 
     if not association_file.exists():
         # No XSLT association file - try to auto-link standard XSLTs
-        log_info("  No xslt_association.json found - attempting auto-link with standard XSLTs")
+        log_info(
+            "  No xslt_association.json found - attempting auto-link with standard XSLTs"
+        )
         list_xslt_name = "list_stylesheet.xsl"
         detail_xslt_name = "detail_stylesheet.xsl"
     else:
@@ -276,7 +293,7 @@ def restore_template_xslt_association(template_dir, template_id, request):
             template,  # Pass template, not rendering object
             list_xslt=list_xslt,
             default_detail_xslt=detail_xslt,
-            list_detail_xslt=[list_xslt] if list_xslt else []
+            list_detail_xslt=[list_xslt] if list_xslt else [],
         )
 
         log_success(f"  Linked XSLTs to template (Rendering ID: {rendering.id})")
@@ -284,6 +301,7 @@ def restore_template_xslt_association(template_dir, template_id, request):
     except Exception as e:
         log_error(f"  Failed to restore XSLT associations: {e}")
         import traceback
+
         traceback.print_exc()
 
 
@@ -304,7 +322,9 @@ def restore_data(schemas_dir):
         log_error("Could not retrieve global workspace! Records will not be visible.")
         log_info("You may need to create the global workspace first.")
     else:
-        log_info(f"Using global workspace: {global_workspace.title} (ID: {global_workspace.id})")
+        log_info(
+            f"Using global workspace: {global_workspace.title} (ID: {global_workspace.id})"
+        )
 
     # Find all template directories
     template_dirs = [d for d in schemas_path.iterdir() if d.is_dir()]
@@ -344,7 +364,9 @@ def restore_data(schemas_dir):
             except Exception:
                 # Create new template
                 from core_main_app.components.template.models import Template
-                from core_main_app.components.template_version_manager.models import TemplateVersionManager
+                from core_main_app.components.template_version_manager.models import (
+                    TemplateVersionManager,
+                )
                 import hashlib
 
                 # Create template
@@ -365,7 +387,9 @@ def restore_data(schemas_dir):
                 # 2. Call template_api.upsert(template)
                 # 3. Set template_vm.current
                 # 4. Save everything
-                template_vm = template_version_manager_api.insert(template_vm, template, request=request)
+                template_vm = template_version_manager_api.insert(
+                    template_vm, template, request=request
+                )
 
                 # Get template ID from the inserted template_vm
                 template_id = template_vm.current
@@ -386,7 +410,7 @@ def restore_data(schemas_dir):
                             xml_content = f.read()
 
                         # Read record metadata if exists
-                        metadata_file = xml_file.with_suffix('.xml.metadata.json')
+                        metadata_file = xml_file.with_suffix(".xml.metadata.json")
                         metadata = {}
                         if metadata_file.exists():
                             with metadata_file.open(encoding="utf-8") as f:
@@ -411,7 +435,9 @@ def restore_data(schemas_dir):
                                 original_user = User.objects.get(id=original_user_id)
                                 owner_id = str(original_user.id)
                             except User.DoesNotExist:
-                                log_warning(f"  Original user (ID: {original_user_id}) not found, using admin")
+                                log_warning(
+                                    f"  Original user (ID: {original_user_id}) not found, using admin"
+                                )
 
                         # Create Data object
                         record = Data()
@@ -427,7 +453,11 @@ def restore_data(schemas_dir):
                         record = data_api.upsert(record, request=request)
 
                         # Determine workspace and assign if needed
-                        workspace = global_workspace if metadata.get("is_global_workspace", True) else None
+                        workspace = (
+                            global_workspace
+                            if metadata.get("is_global_workspace", True)
+                            else None
+                        )
                         if workspace:
                             record.workspace = workspace
                             record = data_api.upsert(record, request=request)
@@ -440,11 +470,17 @@ def restore_data(schemas_dir):
                             owner_display = f"ID:{owner_id}"
 
                         # Format workspace info
-                        workspace_display = f"{workspace.title} (ID: {workspace.id})" if workspace else "None"
+                        workspace_display = (
+                            f"{workspace.title} (ID: {workspace.id})"
+                            if workspace
+                            else "None"
+                        )
 
                         restored_count += 1
                         # Fixed-width columns for easy comparison
-                        log_info(f"  Restored record: {title:<40} | Owner: {owner_display:<15} | Workspace: {workspace_display}")
+                        log_info(
+                            f"  Restored record: {title:<40} | Owner: {owner_display:<15} | Workspace: {workspace_display}"
+                        )
 
                     except Exception as e:
                         log_error(f"  Failed to restore record {xml_file.name}: {e}")
@@ -452,13 +488,18 @@ def restore_data(schemas_dir):
                 if xml_files:
                     skipped_count = len(xml_files) - restored_count
                     if skipped_count > 0:
-                        log_success(f"Restored {restored_count}/{len(xml_files)} records for template '{template_title}' ({skipped_count} skipped)")
+                        log_success(
+                            f"Restored {restored_count}/{len(xml_files)} records for template '{template_title}' ({skipped_count} skipped)"
+                        )
                     else:
-                        log_success(f"Restored {restored_count} records for template '{template_title}'")
+                        log_success(
+                            f"Restored {restored_count} records for template '{template_title}'"
+                        )
 
         except Exception as e:
             log_error(f"Failed to restore template from {template_dir.name}: {e}")
             import traceback
+
             traceback.print_exc()
 
     return True
@@ -475,10 +516,10 @@ def restore_queries(queries_dir):
 
     try:
         from core_explore_keyword_app.components.persistent_query_keyword import (
-            api as persistent_query_api
+            api as persistent_query_api,
         )
         from core_explore_keyword_app.components.persistent_query_keyword.models import (
-            PersistentQueryKeyword
+            PersistentQueryKeyword,
         )
     except ImportError:
         log_warning("core_explore_keyword_app not available, skipping queries")

--- a/deployment/scripts/seed_demo_records.py
+++ b/deployment/scripts/seed_demo_records.py
@@ -14,13 +14,18 @@ import random
 import sys
 from pathlib import Path
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.demo_settings"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.demo_settings"),
+)
 sys.path.insert(0, "/srv/nexuslims")
 
 import django
+
 django.setup()
 
 import logging
+
 logging.getLogger("core_main_app").setLevel(logging.ERROR)
 
 
@@ -32,11 +37,14 @@ SCHEMA_TITLE = "Nexus Experiment Schema"
 def log_success(msg):
     print(f"✓ {msg}")
 
+
 def log_warning(msg):
     print(f"⚠ {msg}")
 
+
 def log_error(msg):
     print(f"✗ {msg}")
+
 
 def log_info(msg):
     print(f"→ {msg}")
@@ -69,7 +77,9 @@ def seed_records():
     User = get_user_model()
     uploader = User.objects.filter(username=UPLOADER_USERNAME).first()
     if not uploader:
-        log_error(f"Uploader user '{UPLOADER_USERNAME}' not found - run init_environment.py first")
+        log_error(
+            f"Uploader user '{UPLOADER_USERNAME}' not found - run init_environment.py first"
+        )
         return
 
     factory = RequestFactory()
@@ -78,7 +88,9 @@ def seed_records():
 
     # Get the NexusLIMS template via the version manager (same pattern as init_environment.py)
     try:
-        tvm = tvm_api.get_active_global_version_manager_by_title(SCHEMA_TITLE, request=request)
+        tvm = tvm_api.get_active_global_version_manager_by_title(
+            SCHEMA_TITLE, request=request
+        )
         template = template_api.get_by_id(tvm.current, request=request)
     except Exception as e:
         log_error(f"Could not find '{SCHEMA_TITLE}' template: {e}")
@@ -125,12 +137,15 @@ def seed_records():
             errors += 1
 
     print("=" * 60)
-    log_success(f"Seeding complete: {uploaded} uploaded, {skipped} skipped, {errors} errors")
+    log_success(
+        f"Seeding complete: {uploaded} uploaded, {skipped} skipped, {errors} errors"
+    )
 
 
 def main():
     from django.conf import settings
-    if not getattr(settings, 'IS_PUBLIC_DEMO', False):
+
+    if not getattr(settings, "IS_PUBLIC_DEMO", False):
         log_warning("IS_PUBLIC_DEMO is not True - are you using demo_settings?")
 
     print("=" * 60)

--- a/deployment/scripts/show_stats.py
+++ b/deployment/scripts/show_stats.py
@@ -7,9 +7,13 @@ import os
 import sys
 
 # Django setup
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"))
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    os.getenv("DJANGO_SETTINGS_MODULE", "config.settings.dev_settings"),
+)
 sys.path.insert(0, "/srv/nexuslims")
 import django
+
 django.setup()
 
 from django.contrib.auth import get_user_model

--- a/docs/changes/22.misc.md
+++ b/docs/changes/22.misc.md
@@ -1,0 +1,1 @@
+Upgraded the underlying CDCS/MDCS base from version 3.20.0 to 3.21.0, bringing in the latest upstream improvements including an improved dashboard, a blob upload file extension validator, and various bug fixes and minor improvements.

--- a/mdcs/__init__.py
+++ b/mdcs/__init__.py
@@ -1,5 +1,4 @@
-""" This is needed for running celery
-"""
+"""This is needed for running celery"""
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.

--- a/mdcs/celery.py
+++ b/mdcs/celery.py
@@ -1,5 +1,4 @@
-""" Celery instance configuration
-"""
+"""Celery instance configuration"""
 
 import os
 

--- a/mdcs/core_settings.py
+++ b/mdcs/core_settings.py
@@ -1,20 +1,17 @@
-""" Django settings for core applications.
-"""
+"""Django settings for core applications."""
 
 import os
 
 SERVER_URI = os.environ["SERVER_URI"] if "SERVER_URI" in os.environ else None
 
-PROJECT_VERSION = os.getenv("PROJECT_VERSION", "3.20.0")
+PROJECT_VERSION = os.getenv("PROJECT_VERSION", "3.21.0")
 """ :py:class:`str`: Project version number.
 """
 
 # Website customization
 WEBSITE_SHORT_TITLE = "NexusLIMS"
 CUSTOM_DATA = "Experimental Records"
-CUSTOM_NAME = (
-    os.environ["SERVER_NAME"] if "SERVER_NAME" in os.environ else "NexusLIMS"
-)
+CUSTOM_NAME = os.environ["SERVER_NAME"] if "SERVER_NAME" in os.environ else "NexusLIMS"
 CUSTOM_TITLE = "Welcome to NexusLIMS!"
 MAX_DOCUMENT_EDITING_SIZE = 25 * 1024 * 1024  # (25 MB)
 
@@ -124,9 +121,7 @@ ID_PROVIDER_PREFIX_DEFAULT = os.getenv(
     "ID_PROVIDER_PREFIX_DEFAULT", ID_PROVIDER_PREFIXES[0]
 )
 
-ID_PROVIDER_PREFIX_BLOB = os.getenv(
-    "ID_PROVIDER_PREFIX_BLOB", ID_PROVIDER_PREFIXES[0]
-)
+ID_PROVIDER_PREFIX_BLOB = os.getenv("ID_PROVIDER_PREFIX_BLOB", ID_PROVIDER_PREFIXES[0])
 
 PID_PATH = os.getenv("PID_PATH", os.getenv("PID_XPATH", "Experiment.@pid"))
 """ string: location of the PID in the document, specified as dot notation
@@ -140,9 +135,7 @@ ENABLE_ALLAUTH = os.getenv("ENABLE_ALLAUTH", "False").lower() == "true"
 """ boolean: enable Django-allauth
 """
 
-ENABLE_SAML2_SSO_AUTH = (
-    os.getenv("ENABLE_SAML2_SSO_AUTH", "False").lower() == "true"
-)
+ENABLE_SAML2_SSO_AUTH = os.getenv("ENABLE_SAML2_SSO_AUTH", "False").lower() == "true"
 """ boolean: enable SAML2 SSO authentication.
 """
 
@@ -150,7 +143,7 @@ ENABLE_HANDLE_PID = os.getenv("ENABLE_HANDLE_PID", "False").lower() == "true"
 """ boolean: enable handle server PID support.
 """
 
-MONGODB_INDEXING = False # always disabled in NexusLIMS
+MONGODB_INDEXING = False  # always disabled in NexusLIMS
 # MONGODB_INDEXING = os.getenv("MONGODB_INDEXING", "True").lower() == "true"
 """ :py:class:`bool`: Use MongoDB for data indexing.
     If True:
@@ -158,12 +151,12 @@ MONGODB_INDEXING = False # always disabled in NexusLIMS
         - queries will be executed against MongoDB.
 """
 
-MONGODB_ASYNC_SAVE = False # always disabled in NexusLIMS
+MONGODB_ASYNC_SAVE = False  # always disabled in NexusLIMS
 """ :py:class:`bool`: Save data in MongoDB asynchronously.
     If True, data are saved in MongoDB asynchronously.
 """
 
-GRIDFS_STORAGE = False # always disabled in NexusLIMS
+GRIDFS_STORAGE = False  # always disabled in NexusLIMS
 # GRIDFS_STORAGE = os.getenv("GRIDFS_STORAGE", "True").lower() == "true"
 """ :py:class:`bool`: Use GridFS for file storage.
 """
@@ -215,6 +208,19 @@ CAN_SET_WORKSPACE_PUBLIC = True
 """ :py:class:`bool`: Allow setting a workspace to be publicly accessible.
 """
 
+BLOB_EXTENSIONS = os.getenv(
+    "BLOB_EXTENSIONS",
+    "csv,xls,xlsx,txt,doc,docx,ppt,pptx,pdf,xml,xsl,xslt,json,yaml,jpg,jpeg,png,tiff",
+).split(",")
+""" :py:class:`list`: Allowed file extensions for blob uploads.
+"""
+
+ALLAUTH_ENABLE_GROUP_SYNC_ON_LOGIN = (
+    os.getenv("ALLAUTH_ENABLE_GROUP_SYNC_ON_LOGIN", "False").lower() == "true"
+)
+""" :py:class:`bool`: Automatically create and assign groups from Identity Provider on login.
+"""
+
 BOOTSTRAP_VERSION = os.getenv("BOOTSTRAP_VERSION", "5.1.3")
 """ :py:class:`str`: Version of the boostrap library.
 """
@@ -231,8 +237,7 @@ ENABLE_JSON_SCHEMA_SUPPORT = (
 """
 
 BACKWARD_COMPATIBILITY_DATA_XML_CONTENT = (
-    os.getenv("BACKWARD_COMPATIBILITY_DATA_XML_CONTENT", "True").lower()
-    == "true"
+    os.getenv("BACKWARD_COMPATIBILITY_DATA_XML_CONTENT", "True").lower() == "true"
 )
 """ :py:class:`bool`: Set to `True` to continue using Data.xml_content (deprecated)
     instead of Data.content in the REST API.

--- a/mdcs/dev_settings.py
+++ b/mdcs/dev_settings.py
@@ -1,5 +1,4 @@
-""" Development Settings
-"""
+"""Development Settings"""
 
 from dotenv import load_dotenv
 

--- a/mdcs/settings.py
+++ b/mdcs/settings.py
@@ -21,18 +21,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = (
-    os.environ["DJANGO_SECRET_KEY"]
-    if "DJANGO_SECRET_KEY" in os.environ
-    else None
+    os.environ["DJANGO_SECRET_KEY"] if "DJANGO_SECRET_KEY" in os.environ else None
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
 ALLOWED_HOSTS = (
-    os.environ["ALLOWED_HOSTS"].split(",")
-    if "ALLOWED_HOSTS" in os.environ
-    else []
+    os.environ["ALLOWED_HOSTS"].split(",") if "ALLOWED_HOSTS" in os.environ else []
 )
 
 # Databases
@@ -41,27 +37,17 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "HOST": (
-            os.environ["POSTGRES_HOST"]
-            if "POSTGRES_HOST" in os.environ
-            else None
+            os.environ["POSTGRES_HOST"] if "POSTGRES_HOST" in os.environ else None
         ),
         "PORT": (
-            int(os.environ["POSTGRES_PORT"])
-            if "POSTGRES_PORT" in os.environ
-            else 5432
+            int(os.environ["POSTGRES_PORT"]) if "POSTGRES_PORT" in os.environ else 5432
         ),
-        "NAME": (
-            os.environ["POSTGRES_DB"] if "POSTGRES_DB" in os.environ else None
-        ),
+        "NAME": (os.environ["POSTGRES_DB"] if "POSTGRES_DB" in os.environ else None),
         "USER": (
-            os.environ["POSTGRES_USER"]
-            if "POSTGRES_USER" in os.environ
-            else None
+            os.environ["POSTGRES_USER"] if "POSTGRES_USER" in os.environ else None
         ),
         "PASSWORD": (
-            os.environ["POSTGRES_PASS"]
-            if "POSTGRES_PASS" in os.environ
-            else None
+            os.environ["POSTGRES_PASS"] if "POSTGRES_PASS" in os.environ else None
         ),
     }
 }
@@ -102,11 +88,9 @@ INSTALLED_APPS = (
     "captcha",
     "django_celery_beat",
     "fontawesomefree",
-
     # NexusLIMS customizations (must come before core apps)
-    'nexuslims_overrides',
-    'nexuslims_annotate',
-
+    "nexuslims_overrides",
+    "nexuslims_annotate",
     # Core apps
     "core_main_app",
     "core_exporters_app",
@@ -168,9 +152,9 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "core_main_app.utils.custom_context_processors.domain_context_processor",  # Needed by any curator app
                 "django.template.context_processors.i18n",
-                'nexuslims_overrides.context_processors.nexuslims_settings',
-                'nexuslims_overrides.context_processors.nexuslims_features',
-                'nexuslims_overrides.context_processors.nexuslims_colors',
+                "nexuslims_overrides.context_processors.nexuslims_settings",
+                "nexuslims_overrides.context_processors.nexuslims_features",
+                "nexuslims_overrides.context_processors.nexuslims_colors",
             ],
         },
     },
@@ -291,7 +275,8 @@ REST_FRAMEWORK = {
 SPECTACULAR_SETTINGS = {
     "TITLE": WEBSITE_SHORT_TITLE,  # noqa: F405 (core setting)
     "DESCRIPTION": os.getenv(
-        "PROJECT_DESCRIPTION", "API endpoints for programmatically accessing data from NexusLIMS"
+        "PROJECT_DESCRIPTION",
+        "API endpoints for programmatically accessing data from NexusLIMS",
     ),
     "VERSION": PROJECT_VERSION,  # noqa: F405 (core setting)
     "SERVE_INCLUDE_SCHEMA": False,
@@ -494,9 +479,7 @@ if ENABLE_SAML2_SSO_AUTH:  # noqa: F405 (core setting)
     if "djangosaml2" not in INSTALLED_APPS:
         INSTALLED_APPS = INSTALLED_APPS + ("djangosaml2",)
     if "djangosaml2.middleware.SamlSessionMiddleware" not in MIDDLEWARE:
-        MIDDLEWARE = MIDDLEWARE + (
-            "djangosaml2.middleware.SamlSessionMiddleware",
-        )
+        MIDDLEWARE = MIDDLEWARE + ("djangosaml2.middleware.SamlSessionMiddleware",)
     AUTHENTICATION_BACKENDS = (
         "django.contrib.auth.backends.ModelBackend",
         "djangosaml2.backends.Saml2Backend",
@@ -525,15 +508,13 @@ if ENABLE_SAML2_SSO_AUTH:  # noqa: F405 (core setting)
         server_uri=SERVER_URI,  # noqa: F405 (core setting)
         base_dir=BASE_DIR,  # noqa: F405 (core setting)
     )
-    SAML_ACS_FAILURE_RESPONSE_FUNCTION = (
-        "core_main_app.views.user.views.saml2_failure"
-    )
+    SAML_ACS_FAILURE_RESPONSE_FUNCTION = "core_main_app.views.user.views.saml2_failure"
 
 # configure handle server PIDs according to environment settings
 if ENABLE_HANDLE_PID:  # noqa: F405 (core setting)
     HDL_USER = (
         f"300%3A{ID_PROVIDER_PREFIX_DEFAULT}/"  # noqa: F405 (core setting)
-        f'{os.getenv("HANDLE_NET_USER", "ADMIN")}'
+        f"{os.getenv('HANDLE_NET_USER', 'ADMIN')}"
     )
 
     ID_PROVIDER_SYSTEM_NAME = "handle.net"
@@ -541,9 +522,7 @@ if ENABLE_HANDLE_PID:  # noqa: F405 (core setting)
         "class": "core_linked_records_app.utils.providers.handle_net.HandleNetSystem",
         "args": [
             os.getenv("HANDLE_NET_LOOKUP_URL", "https://hdl.handle.net"),
-            os.getenv(
-                "HANDLE_NET_REGISTRATION_URL", "https://handle-net.domain"
-            ),
+            os.getenv("HANDLE_NET_REGISTRATION_URL", "https://handle-net.domain"),
             HDL_USER,
             os.getenv("HANDLE_NET_SECRET_KEY", "admin"),
         ],

--- a/mdcs/urls.py
+++ b/mdcs/urls.py
@@ -26,9 +26,7 @@ admin.autodiscover()
 urlpatterns = [
     re_path(rf"^{ADMIN_URLS_PREFIX}admin/", admin.site.urls),
     re_path(rf"^{ADMIN_URLS_PREFIX}core-admin/", core_admin_site.urls),
-    re_path(
-        r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")
-    ),
+    re_path(r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     # NexusLIMS overrides MUST come before core_main_app to override its URLs
     re_path(r"^", include("nexuslims_overrides.urls")),
     *(

--- a/mdcs_home/admin.py
+++ b/mdcs_home/admin.py
@@ -1,12 +1,9 @@
-""" Admin urls
-"""
+"""Admin urls"""
 
 from core_main_app.utils.admin_site.model_admin_class import (
     register_simple_history_models,
 )
 from django.conf import settings
 
-DJANGO_SIMPLE_HISTORY_MODELS = getattr(
-    settings, "DJANGO_SIMPLE_HISTORY_MODELS", None
-)
+DJANGO_SIMPLE_HISTORY_MODELS = getattr(settings, "DJANGO_SIMPLE_HISTORY_MODELS", None)
 register_simple_history_models(DJANGO_SIMPLE_HISTORY_MODELS)

--- a/mdcs_home/urls.py
+++ b/mdcs_home/urls.py
@@ -1,5 +1,4 @@
-"""mdcs URL Configuration
-"""
+"""mdcs URL Configuration"""
 
 from django.urls import re_path
 

--- a/nexuslims_annotate/apps.py
+++ b/nexuslims_annotate/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class NexusLIMSAnnotateConfig(AppConfig):
-    name = 'nexuslims_annotate'
-    verbose_name = 'NexusLIMS Record Annotator'
+    name = "nexuslims_annotate"
+    verbose_name = "NexusLIMS Record Annotator"

--- a/nexuslims_annotate/urls.py
+++ b/nexuslims_annotate/urls.py
@@ -2,9 +2,19 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('<str:record_id>/descriptions/', views.annotate_descriptions, name='nexuslims_annotate_descriptions'),
-    path('<str:record_id>/panel/', views.annotate_panel, name='nexuslims_annotate_panel'),
-    path('<str:record_id>/save/', views.annotate_save, name='nexuslims_annotate_save'),
-    path('<str:record_id>/save-one/', views.annotate_save_one, name='nexuslims_annotate_save_one'),
-    path('<str:record_id>/', views.annotate_record, name='nexuslims_annotate_record'),
+    path(
+        "<str:record_id>/descriptions/",
+        views.annotate_descriptions,
+        name="nexuslims_annotate_descriptions",
+    ),
+    path(
+        "<str:record_id>/panel/", views.annotate_panel, name="nexuslims_annotate_panel"
+    ),
+    path("<str:record_id>/save/", views.annotate_save, name="nexuslims_annotate_save"),
+    path(
+        "<str:record_id>/save-one/",
+        views.annotate_save_one,
+        name="nexuslims_annotate_save_one",
+    ),
+    path("<str:record_id>/", views.annotate_record, name="nexuslims_annotate_record"),
 ]

--- a/nexuslims_annotate/views.py
+++ b/nexuslims_annotate/views.py
@@ -18,30 +18,138 @@ from core_main_app.components.data import api as data_api
 
 logger = logging.getLogger(__name__)
 
-NS = 'https://data.nist.gov/od/dm/nexus/experiment/v1.0'
-NS_MAP = {'nx': NS}
+NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
+NS_MAP = {"nx": NS}
 
-_VALID_ELEMENT_SYMBOLS = frozenset([
-    'H','He','Li','Be','B','C','N','O','F','Ne',
-    'Na','Mg','Al','Si','P','S','Cl','Ar','K','Ca',
-    'Sc','Ti','V','Cr','Mn','Fe','Co','Ni','Cu','Zn',
-    'Ga','Ge','As','Se','Br','Kr','Rb','Sr','Y','Zr',
-    'Nb','Mo','Tc','Ru','Rh','Pd','Ag','Cd','In','Sn',
-    'Sb','Te','I','Xe','Cs','Ba','La','Ce','Pr','Nd',
-    'Pm','Sm','Eu','Gd','Tb','Dy','Ho','Er','Tm','Yb',
-    'Lu','Hf','Ta','W','Re','Os','Ir','Pt','Au','Hg',
-    'Tl','Pb','Bi','Po','At','Rn','Fr','Ra','Ac','Th',
-    'Pa','U','Np','Pu','Am','Cm','Bk','Cf','Es','Fm',
-    'Md','No','Lr','Rf','Db','Sg','Bh','Hs','Mt','Ds',
-    'Rg','Cn','Nh','Fl','Mc','Lv','Ts','Og',
-])
+_VALID_ELEMENT_SYMBOLS = frozenset(
+    [
+        "H",
+        "He",
+        "Li",
+        "Be",
+        "B",
+        "C",
+        "N",
+        "O",
+        "F",
+        "Ne",
+        "Na",
+        "Mg",
+        "Al",
+        "Si",
+        "P",
+        "S",
+        "Cl",
+        "Ar",
+        "K",
+        "Ca",
+        "Sc",
+        "Ti",
+        "V",
+        "Cr",
+        "Mn",
+        "Fe",
+        "Co",
+        "Ni",
+        "Cu",
+        "Zn",
+        "Ga",
+        "Ge",
+        "As",
+        "Se",
+        "Br",
+        "Kr",
+        "Rb",
+        "Sr",
+        "Y",
+        "Zr",
+        "Nb",
+        "Mo",
+        "Tc",
+        "Ru",
+        "Rh",
+        "Pd",
+        "Ag",
+        "Cd",
+        "In",
+        "Sn",
+        "Sb",
+        "Te",
+        "I",
+        "Xe",
+        "Cs",
+        "Ba",
+        "La",
+        "Ce",
+        "Pr",
+        "Nd",
+        "Pm",
+        "Sm",
+        "Eu",
+        "Gd",
+        "Tb",
+        "Dy",
+        "Ho",
+        "Er",
+        "Tm",
+        "Yb",
+        "Lu",
+        "Hf",
+        "Ta",
+        "W",
+        "Re",
+        "Os",
+        "Ir",
+        "Pt",
+        "Au",
+        "Hg",
+        "Tl",
+        "Pb",
+        "Bi",
+        "Po",
+        "At",
+        "Rn",
+        "Fr",
+        "Ra",
+        "Ac",
+        "Th",
+        "Pa",
+        "U",
+        "Np",
+        "Pu",
+        "Am",
+        "Cm",
+        "Bk",
+        "Cf",
+        "Es",
+        "Fm",
+        "Md",
+        "No",
+        "Lr",
+        "Rf",
+        "Db",
+        "Sg",
+        "Bh",
+        "Hs",
+        "Mt",
+        "Ds",
+        "Rg",
+        "Cn",
+        "Nh",
+        "Fl",
+        "Mc",
+        "Lv",
+        "Ts",
+        "Og",
+    ]
+)
 
 
 def _get_title(xml_content):
     """Extract the experiment title from XML content."""
     root = ET.fromstring(xml_content)
-    title_el = root.find('nx:title', NS_MAP)
-    return title_el.text if title_el is not None else ''
+    title_el = root.find("nx:title", NS_MAP)
+    return title_el.text if title_el is not None else ""
 
 
 def _apply_title(xml_content, new_title):
@@ -56,32 +164,36 @@ def _apply_title(xml_content, new_title):
 
 def _parse_datasets(xml_content):
     """Parse XML content and return a list of dataset dicts."""
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
 
-    preview_base = os.getenv('XSLT_PREVIEW_BASE_URL', '').rstrip('/')
+    preview_base = os.getenv("XSLT_PREVIEW_BASE_URL", "").rstrip("/")
     datasets = []
     index = 0
 
-    for activity in root.findall(f'nx:acquisitionActivity', NS_MAP):
-        seqno = activity.get('seqno', '')
-        for dataset_el in activity.findall(f'nx:dataset', NS_MAP):
-            name_el = dataset_el.find('nx:name', NS_MAP)
-            desc_el = dataset_el.find('nx:description', NS_MAP)
-            preview_el = dataset_el.find('nx:preview', NS_MAP)
+    for activity in root.findall("nx:acquisitionActivity", NS_MAP):
+        seqno = activity.get("seqno", "")
+        for dataset_el in activity.findall("nx:dataset", NS_MAP):
+            name_el = dataset_el.find("nx:name", NS_MAP)
+            desc_el = dataset_el.find("nx:description", NS_MAP)
+            preview_el = dataset_el.find("nx:preview", NS_MAP)
 
-            name = name_el.text if name_el is not None else ''
-            description = desc_el.text if desc_el is not None else ''
+            name = name_el.text if name_el is not None else ""
+            description = desc_el.text if desc_el is not None else ""
             preview_path = preview_el.text if preview_el is not None else None
-            preview_url = f'{preview_base}/{preview_path.lstrip("/")}' if preview_path else None
+            preview_url = (
+                f"{preview_base}/{preview_path.lstrip('/')}" if preview_path else None
+            )
 
-            datasets.append({
-                'index': index,
-                'name': name,
-                'description': description or '',
-                'preview_url': preview_url,
-                'activity_seqno': seqno,
-            })
+            datasets.append(
+                {
+                    "index": index,
+                    "name": name,
+                    "description": description or "",
+                    "preview_url": preview_url,
+                    "activity_seqno": seqno,
+                }
+            )
             index += 1
 
     return datasets
@@ -91,19 +203,21 @@ def _parse_activities(xml_content):
     """Return a list of activity dicts for the move UI."""
     root = ET.fromstring(xml_content)
     activities = []
-    for activity in root.findall('nx:acquisitionActivity', NS_MAP):
-        seqno = activity.get('seqno', '')
-        start_el = activity.find('nx:startTime', NS_MAP)
-        start_time = start_el.text if start_el is not None else ''
-        sample_id_el = activity.find('nx:sampleID', NS_MAP)
-        sample_id = sample_id_el.text if sample_id_el is not None else ''
-        dataset_count = len(activity.findall('nx:dataset', NS_MAP))
-        activities.append({
-            'seqno': seqno,
-            'start_time': start_time,
-            'dataset_count': dataset_count,
-            'sample_id': sample_id,
-        })
+    for activity in root.findall("nx:acquisitionActivity", NS_MAP):
+        seqno = activity.get("seqno", "")
+        start_el = activity.find("nx:startTime", NS_MAP)
+        start_time = start_el.text if start_el is not None else ""
+        sample_id_el = activity.find("nx:sampleID", NS_MAP)
+        sample_id = sample_id_el.text if sample_id_el is not None else ""
+        dataset_count = len(activity.findall("nx:dataset", NS_MAP))
+        activities.append(
+            {
+                "seqno": seqno,
+                "start_time": start_time,
+                "dataset_count": dataset_count,
+                "sample_id": sample_id,
+            }
+        )
     return activities
 
 
@@ -119,92 +233,102 @@ def _build_activity_groups(activities, datasets):
     """
     by_seqno = {}
     for ds in datasets:
-        by_seqno.setdefault(ds['activity_seqno'], []).append(ds)
-    return [{'seqno': a['seqno'], 'datasets': by_seqno.get(a['seqno'], [])} for a in activities]
+        by_seqno.setdefault(ds["activity_seqno"], []).append(ds)
+    return [
+        {"seqno": a["seqno"], "datasets": by_seqno.get(a["seqno"], [])}
+        for a in activities
+    ]
 
 
 def _parse_samples(xml_content):
     """Parse XML and return a list of sample dicts."""
     root = ET.fromstring(xml_content)
     samples = []
-    for sample_el in root.findall('nx:sample', NS_MAP):
-        name_el = sample_el.find('nx:name', NS_MAP)
-        desc_el = sample_el.find('nx:description', NS_MAP)
-        elements_el = sample_el.find('nx:elements', NS_MAP)
+    for sample_el in root.findall("nx:sample", NS_MAP):
+        name_el = sample_el.find("nx:name", NS_MAP)
+        desc_el = sample_el.find("nx:description", NS_MAP)
+        elements_el = sample_el.find("nx:elements", NS_MAP)
 
         elements = []
         if elements_el is not None:
             elements = [
-                child.tag.split('}')[-1] if '}' in child.tag else child.tag
+                child.tag.split("}")[-1] if "}" in child.tag else child.tag
                 for child in elements_el
             ]
 
-        samples.append({
-            'id': sample_el.get('id', ''),
-            'ref': sample_el.get('ref', ''),
-            'name': name_el.text if name_el is not None else '',
-            'description': desc_el.text if desc_el is not None else '',
-            'elements': elements,
-        })
+        samples.append(
+            {
+                "id": sample_el.get("id", ""),
+                "ref": sample_el.get("ref", ""),
+                "name": name_el.text if name_el is not None else "",
+                "description": desc_el.text if desc_el is not None else "",
+                "elements": elements,
+            }
+        )
     return samples
 
 
 def _apply_samples(xml_content, samples_data):
     """Replace all <sample> elements with the provided ordered list."""
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
 
-    for sample_el in root.findall('nx:sample', NS_MAP):
+    for sample_el in root.findall("nx:sample", NS_MAP):
         root.remove(sample_el)
 
     # Find insertion point: after title/id/summary, before project/acquisitionActivity/notes
     insert_pos = 0
     for i, child in enumerate(root):
-        local = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if local in ('title', 'id', 'summary'):
+        local = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if local in ("title", "id", "summary"):
             insert_pos = i + 1
 
     for offset, sample_data in enumerate(samples_data):
-        sample_el = ET.Element(f'{{{NS}}}sample')
-        sid = (sample_data.get('id') or '').strip()
+        sample_el = ET.Element(f"{{{NS}}}sample")
+        sid = (sample_data.get("id") or "").strip()
         if sid:
-            sample_el.set('id', sid)
-        ref = (sample_data.get('ref') or '').strip()
+            sample_el.set("id", sid)
+        ref = (sample_data.get("ref") or "").strip()
         if ref:
-            sample_el.set('ref', ref)
+            sample_el.set("ref", ref)
 
-        name = (sample_data.get('name') or '').strip()
+        name = (sample_data.get("name") or "").strip()
         if name:
-            name_el = ET.SubElement(sample_el, f'{{{NS}}}name')
+            name_el = ET.SubElement(sample_el, f"{{{NS}}}name")
             name_el.text = name
 
-        description = (sample_data.get('description') or '').strip()
+        description = (sample_data.get("description") or "").strip()
         if description:
-            desc_el = ET.SubElement(sample_el, f'{{{NS}}}description')
+            desc_el = ET.SubElement(sample_el, f"{{{NS}}}description")
             desc_el.text = description
 
-        elements = [s for s in (sample_data.get('elements') or []) if s in _VALID_ELEMENT_SYMBOLS]
+        elements = [
+            s
+            for s in (sample_data.get("elements") or [])
+            if s in _VALID_ELEMENT_SYMBOLS
+        ]
         if elements:
-            elements_el = ET.SubElement(sample_el, f'{{{NS}}}elements')
+            elements_el = ET.SubElement(sample_el, f"{{{NS}}}elements")
             for symbol in elements:
-                ET.SubElement(elements_el, f'{{{NS}}}{symbol}')
+                ET.SubElement(elements_el, f"{{{NS}}}{symbol}")
 
         root.insert(insert_pos + offset, sample_el)
 
-    return ET.tostring(root, encoding='unicode', xml_declaration=False)
+    return ET.tostring(root, encoding="unicode", xml_declaration=False)
 
 
 def _renumber_activities(xml_content):
     """Rewrite all seqno attributes to consecutive 0-based integers in XML order."""
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
-    for i, activity in enumerate(root.findall('nx:acquisitionActivity', NS_MAP)):
-        activity.set('seqno', str(i))
-    return ET.tostring(root, encoding='unicode', xml_declaration=False)
+    for i, activity in enumerate(root.findall("nx:acquisitionActivity", NS_MAP)):
+        activity.set("seqno", str(i))
+    return ET.tostring(root, encoding="unicode", xml_declaration=False)
 
 
-def _apply_activity_mutations(xml_content, deleted_seqnos, new_activities, activity_sample_ids,
-                              moves=None):
+def _apply_activity_mutations(
+    xml_content, deleted_seqnos, new_activities, activity_sample_ids, moves=None
+):
     """Delete/insert activities, apply dataset moves, and set sampleID assignments.
 
     deleted_seqnos: list of seqno strings to delete (must have 0 datasets after moves)
@@ -220,33 +344,32 @@ def _apply_activity_mutations(xml_content, deleted_seqnos, new_activities, activ
 
     Raises ValueError if a deleted activity has datasets, or after_seqno is not found.
     """
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
     deleted_seqnos = [str(s) for s in deleted_seqnos]
 
     # Phase 1: insert new activities (before moves so new-* seqnos are valid move targets)
     activities_by_seqno = {
-        a.get('seqno', ''): a
-        for a in root.findall('nx:acquisitionActivity', NS_MAP)
+        a.get("seqno", ""): a for a in root.findall("nx:acquisitionActivity", NS_MAP)
     }
 
     # Phase 2: insert new activities
     for spec in new_activities:
-        temp_id = spec.get('temp_id', '')
-        after_seqno = spec.get('after_seqno')
-        new_el = ET.Element(f'{{{NS}}}acquisitionActivity')
-        new_el.set('seqno', temp_id)
+        temp_id = spec.get("temp_id", "")
+        after_seqno = spec.get("after_seqno")
+        new_el = ET.Element(f"{{{NS}}}acquisitionActivity")
+        new_el.set("seqno", temp_id)
 
         if after_seqno is not None:
             ref = activities_by_seqno.get(str(after_seqno))
             if ref is None:
-                raise ValueError(f'after_seqno {after_seqno!r} not found')
+                raise ValueError(f"after_seqno {after_seqno!r} not found")
             all_children = list(root)
             pos = all_children.index(ref)
             root.insert(pos + 1, new_el)
         else:
             # at_end: append after the last existing activity
-            all_acts = root.findall('nx:acquisitionActivity', NS_MAP)
+            all_acts = root.findall("nx:acquisitionActivity", NS_MAP)
             if all_acts:
                 all_children = list(root)
                 pos = all_children.index(all_acts[-1])
@@ -258,67 +381,66 @@ def _apply_activity_mutations(xml_content, deleted_seqnos, new_activities, activ
 
     # Phase 2b: apply moves so datasets reach their final activities before deletion check
     if moves:
-        xml_intermediate = ET.tostring(root, encoding='unicode', xml_declaration=False)
+        xml_intermediate = ET.tostring(root, encoding="unicode", xml_declaration=False)
         xml_intermediate = _apply_moves(xml_intermediate, moves)
         root = ET.fromstring(xml_intermediate)
 
     # Phase 3: validate and delete (activities must be empty after moves)
     activities_by_seqno = {
-        a.get('seqno', ''): a
-        for a in root.findall('nx:acquisitionActivity', NS_MAP)
+        a.get("seqno", ""): a for a in root.findall("nx:acquisitionActivity", NS_MAP)
     }
     for seqno in deleted_seqnos:
         activity = activities_by_seqno.get(seqno)
         if activity is None:
             continue
-        dataset_count = len(activity.findall(f'{{{NS}}}dataset'))
+        dataset_count = len(activity.findall(f"{{{NS}}}dataset"))
         if dataset_count > 0:
             raise ValueError(
-                f'Activity {seqno} has {dataset_count} dataset(s) and cannot be deleted'
+                f"Activity {seqno} has {dataset_count} dataset(s) and cannot be deleted"
             )
         root.remove(activity)
 
     # Phase 4: build seqno mapping (provisional seqno -> 0-based final position)
-    final_activities = root.findall('nx:acquisitionActivity', NS_MAP)
-    seqno_mapping = {a.get('seqno', ''): str(i) for i, a in enumerate(final_activities)}
+    final_activities = root.findall("nx:acquisitionActivity", NS_MAP)
+    seqno_mapping = {a.get("seqno", ""): str(i) for i, a in enumerate(final_activities)}
 
     # Phase 5: apply sampleID assignments
-    provisional_by_seqno = {a.get('seqno', ''): a for a in final_activities}
+    provisional_by_seqno = {a.get("seqno", ""): a for a in final_activities}
     for seqno_or_temp, sample_id in activity_sample_ids.items():
         activity = provisional_by_seqno.get(str(seqno_or_temp))
         if activity is None:
             continue
-        for sid_el in activity.findall(f'{{{NS}}}sampleID'):
+        for sid_el in activity.findall(f"{{{NS}}}sampleID"):
             activity.remove(sid_el)
         if sample_id is not None:
-            sid_el = ET.Element(f'{{{NS}}}sampleID')
+            sid_el = ET.Element(f"{{{NS}}}sampleID")
             sid_el.text = str(sample_id)
             children = list(activity)
             insert_pos = 0
             for j, child in enumerate(children):
-                local = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-                if local == 'startTime':
+                local = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                if local == "startTime":
                     insert_pos = j + 1
                     break
             activity.insert(insert_pos, sid_el)
 
-    return ET.tostring(root, encoding='unicode', xml_declaration=False), seqno_mapping
+    return ET.tostring(root, encoding="unicode", xml_declaration=False), seqno_mapping
 
 
 def _inject_setup_into_dataset(dataset_el, activity_el):
     """Copy source activity setup params into a dataset's meta elements (non-destructively)."""
-    setup_el = activity_el.find(f'{{{NS}}}setup')
+    setup_el = activity_el.find(f"{{{NS}}}setup")
     if setup_el is None:
         return
-    existing_names = {m.get('name') for m in dataset_el.findall(f'{{{NS}}}meta')}
-    for param in setup_el.findall(f'{{{NS}}}param'):
-        name = param.get('name')
+    existing_names = {m.get("name") for m in dataset_el.findall(f"{{{NS}}}meta")}
+    for param in setup_el.findall(f"{{{NS}}}param"):
+        name = param.get("name")
         if name and name not in existing_names:
-            meta_el = ET.Element(f'{{{NS}}}meta')
-            meta_el.set('name', name)
-            unit = param.get('unit')
+            meta_el = ET.Element(f"{{{NS}}}meta")
+            meta_el.set("name", name)
+            unit = param.get("unit")
             if unit:
-                meta_el.set('unit', unit)
+                meta_el.set("unit", unit)
             meta_el.text = param.text
             dataset_el.append(meta_el)
 
@@ -331,10 +453,10 @@ def _recompute_activity_setup(activity_el, skip_inject=None):
                  activity so they keep only their source-activity metadata and do not
                  pick up unrelated params from the receiving activity.
     """
-    datasets = activity_el.findall(f'{{{NS}}}dataset')
+    datasets = activity_el.findall(f"{{{NS}}}dataset")
     skip_inject = skip_inject or set()
 
-    old_setup = activity_el.find(f'{{{NS}}}setup')
+    old_setup = activity_el.find(f"{{{NS}}}setup")
     if old_setup is not None:
         # Preserve current setup values in each dataset's meta before clearing the setup,
         # so that datasets which stay in this activity don't silently lose their metadata.
@@ -351,8 +473,8 @@ def _recompute_activity_setup(activity_el, skip_inject=None):
     dataset_metas = []
     for ds in datasets:
         metas = {}
-        for meta in ds.findall(f'{{{NS}}}meta'):
-            metas[meta.get('name')] = (meta.text, meta.get('unit'))
+        for meta in ds.findall(f"{{{NS}}}meta"):
+            metas[meta.get("name")] = (meta.text, meta.get("unit"))
         dataset_metas.append(metas)
 
     # Intersection: params with identical name+value+unit across all datasets
@@ -364,12 +486,12 @@ def _recompute_activity_setup(activity_el, skip_inject=None):
     if not common:
         return
 
-    setup_el = ET.Element(f'{{{NS}}}setup')
+    setup_el = ET.Element(f"{{{NS}}}setup")
     for name, (value, unit) in common.items():
-        param_el = ET.SubElement(setup_el, f'{{{NS}}}param')
-        param_el.set('name', name)
+        param_el = ET.SubElement(setup_el, f"{{{NS}}}param")
+        param_el.set("name", name)
         if unit:
-            param_el.set('unit', unit)
+            param_el.set("unit", unit)
         param_el.text = value
 
     # Insert before first dataset
@@ -378,8 +500,8 @@ def _recompute_activity_setup(activity_el, skip_inject=None):
 
     # Remove promoted params from individual dataset meta elements
     for ds in datasets:
-        for meta in list(ds.findall(f'{{{NS}}}meta')):
-            if meta.get('name') in common:
+        for meta in list(ds.findall(f"{{{NS}}}meta")):
+            if meta.get("name") in common:
                 ds.remove(meta)
 
 
@@ -390,18 +512,18 @@ def _dataset_creation_time(dataset_el):
     1. <meta name="Creation Time"> element
     2. Leading timestamp in the dataset <name> (e.g. "2024-01-15 10:05:00 file.dm3")
     """
-    for meta in dataset_el.findall(f'{{{NS}}}meta'):
-        if meta.get('name') == 'Creation Time' and meta.text:
+    for meta in dataset_el.findall(f"{{{NS}}}meta"):
+        if meta.get("name") == "Creation Time" and meta.text:
             try:
                 return datetime.fromisoformat(meta.text.strip())
             except ValueError:
                 pass
-    name_el = dataset_el.find(f'{{{NS}}}name')
+    name_el = dataset_el.find(f"{{{NS}}}name")
     if name_el is not None and name_el.text:
-        m = re.match(r'(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})', name_el.text)
+        m = re.match(r"(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})", name_el.text)
         if m:
             try:
-                return datetime.fromisoformat(m.group(1).replace(' ', 'T'))
+                return datetime.fromisoformat(m.group(1).replace(" ", "T"))
             except ValueError:
                 pass
     return None
@@ -412,7 +534,7 @@ def _sort_datasets_by_creation_time(activity_el):
 
     Datasets without a parseable timestamp keep their relative order and sort last.
     """
-    datasets = list(activity_el.findall(f'{{{NS}}}dataset'))
+    datasets = list(activity_el.findall(f"{{{NS}}}dataset"))
     if len(datasets) <= 1:
         return
     _EPOCH = datetime.min
@@ -439,26 +561,30 @@ def _apply_moves(xml_content, moves):
     # Deduplicate: last move wins for each dataset index
     seen = {}
     for m in moves:
-        idx = m.get('datasetIndex') if isinstance(m, dict) else None
-        target_seqno = m.get('targetActivitySeqno') if isinstance(m, dict) else None
-        if not isinstance(m, dict) or not isinstance(idx, int) or idx < 0 or target_seqno is None:
-            logger.warning('Skipping malformed move entry: %r', m)
+        idx = m.get("datasetIndex") if isinstance(m, dict) else None
+        target_seqno = m.get("targetActivitySeqno") if isinstance(m, dict) else None
+        if (
+            not isinstance(m, dict)
+            or not isinstance(idx, int)
+            or idx < 0
+            or target_seqno is None
+        ):
+            logger.warning("Skipping malformed move entry: %r", m)
             continue
         seen[idx] = m
     moves = list(seen.values())
 
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
 
     # Flat dataset list [(dataset_el, activity_el), ...]
     flat_datasets = []
-    for activity in root.findall('nx:acquisitionActivity', NS_MAP):
-        for ds in activity.findall('nx:dataset', NS_MAP):
+    for activity in root.findall("nx:acquisitionActivity", NS_MAP):
+        for ds in activity.findall("nx:dataset", NS_MAP):
             flat_datasets.append((ds, activity))
 
     activities_by_seqno = {
-        a.get('seqno', ''): a
-        for a in root.findall('nx:acquisitionActivity', NS_MAP)
+        a.get("seqno", ""): a for a in root.findall("nx:acquisitionActivity", NS_MAP)
     }
 
     affected = set()
@@ -469,12 +595,12 @@ def _apply_moves(xml_content, moves):
 
     # Phase 1: inject setup params into each moving dataset before any moves happen
     for m in moves:
-        idx = m['datasetIndex']
-        target_seqno = str(m['targetActivitySeqno'])
+        idx = m["datasetIndex"]
+        target_seqno = str(m["targetActivitySeqno"])
         if idx >= len(flat_datasets):
             continue
         ds_el, src_activity = flat_datasets[idx]
-        src_seqno = src_activity.get('seqno', '')
+        src_seqno = src_activity.get("seqno", "")
         if src_seqno == target_seqno:
             continue
         _inject_setup_into_dataset(ds_el, src_activity)
@@ -484,16 +610,16 @@ def _apply_moves(xml_content, moves):
 
     # Phase 2: physically relocate dataset elements
     for m in moves:
-        idx = m['datasetIndex']
-        target_seqno = str(m['targetActivitySeqno'])
+        idx = m["datasetIndex"]
+        target_seqno = str(m["targetActivitySeqno"])
         if idx >= len(flat_datasets):
             continue
         ds_el, src_activity = flat_datasets[idx]
-        if src_activity.get('seqno', '') == target_seqno:
+        if src_activity.get("seqno", "") == target_seqno:
             continue
         target_activity = activities_by_seqno.get(target_seqno)
         if target_activity is None:
-            logger.warning('Target activity seqno %s not found', target_seqno)
+            logger.warning("Target activity seqno %s not found", target_seqno)
             continue
         src_activity.remove(ds_el)
         target_activity.append(ds_el)
@@ -512,32 +638,32 @@ def _apply_moves(xml_content, moves):
         if activity is not None:
             _sort_datasets_by_creation_time(activity)
 
-    return ET.tostring(root, encoding='unicode', xml_declaration=False)
+    return ET.tostring(root, encoding="unicode", xml_declaration=False)
 
 
 def _apply_descriptions(xml_content, post_data):
     """Update <description> elements in the XML with submitted values."""
-    ET.register_namespace('', NS)
+    ET.register_namespace("", NS)
     root = ET.fromstring(xml_content)
 
     index = 0
-    for activity in root.findall(f'nx:acquisitionActivity', NS_MAP):
-        for dataset_el in activity.findall(f'nx:dataset', NS_MAP):
+    for activity in root.findall("nx:acquisitionActivity", NS_MAP):
+        for dataset_el in activity.findall("nx:dataset", NS_MAP):
             # Remove existing description elements
-            for desc_el in dataset_el.findall('nx:description', NS_MAP):
+            for desc_el in dataset_el.findall("nx:description", NS_MAP):
                 dataset_el.remove(desc_el)
 
-            new_text = post_data.get(f'dataset_{index}_description', '').strip()
+            new_text = post_data.get(f"dataset_{index}_description", "").strip()
             if new_text:
-                desc_el = ET.Element(f'{{{NS}}}description')
+                desc_el = ET.Element(f"{{{NS}}}description")
                 desc_el.text = new_text
 
                 # Find insertion point: after <format> if present, else after <location>
                 children = list(dataset_el)
                 insert_after = None
                 for child in children:
-                    local = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-                    if local in ('format', 'location'):
+                    local = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                    if local in ("format", "location"):
                         insert_after = child
 
                 if insert_after is not None:
@@ -548,7 +674,7 @@ def _apply_descriptions(xml_content, post_data):
 
             index += 1
 
-    return ET.tostring(root, encoding='unicode', xml_declaration=False)
+    return ET.tostring(root, encoding="unicode", xml_declaration=False)
 
 
 @login_required
@@ -561,7 +687,9 @@ def annotate_record(request, record_id):
     try:
         check_can_write(data, request.user)
     except AccessControlError:
-        return HttpResponseForbidden("You do not have permission to annotate this record.")
+        return HttpResponseForbidden(
+            "You do not have permission to annotate this record."
+        )
     try:
         datasets = _parse_datasets(data.content)
         activities = _parse_activities(data.content)
@@ -569,25 +697,34 @@ def annotate_record(request, record_id):
         record_title = _get_title(data.content)
         activity_groups = _build_activity_groups(activities, datasets)
     except ET.ParseError:
-        return render(request, 'nexuslims_annotate/annotate.html', {
-            'data': data,
-            'record_title': '',
-            'datasets': [],
-            'activity_groups': [],
-            'record_id': record_id,
-            'activities': [],
-            'samples': [],
-            'xml_error': True,
-        }, status=500)
-    return render(request, 'nexuslims_annotate/annotate.html', {
-        'data': data,
-        'record_title': record_title,
-        'datasets': datasets,
-        'activity_groups': activity_groups,
-        'record_id': record_id,
-        'activities': activities,
-        'samples': samples,
-    })
+        return render(
+            request,
+            "nexuslims_annotate/annotate.html",
+            {
+                "data": data,
+                "record_title": "",
+                "datasets": [],
+                "activity_groups": [],
+                "record_id": record_id,
+                "activities": [],
+                "samples": [],
+                "xml_error": True,
+            },
+            status=500,
+        )
+    return render(
+        request,
+        "nexuslims_annotate/annotate.html",
+        {
+            "data": data,
+            "record_title": record_title,
+            "datasets": datasets,
+            "activity_groups": activity_groups,
+            "record_id": record_id,
+            "activities": activities,
+            "samples": samples,
+        },
+    )
 
 
 @login_required
@@ -597,23 +734,29 @@ def annotate_panel(request, record_id):
     try:
         data = data_api.get_by_id(record_id, request.user)
     except (DoesNotExist, ModelError):
-        return JsonResponse({'error': 'Record not found'}, status=404)
+        return JsonResponse({"error": "Record not found"}, status=404)
     try:
         check_can_write(data, request.user)
     except AccessControlError:
-        return JsonResponse({'error': 'You do not have permission to annotate this record.'}, status=403)
+        return JsonResponse(
+            {"error": "You do not have permission to annotate this record."}, status=403
+        )
     try:
         datasets = _parse_datasets(data.content)
         activities = _parse_activities(data.content)
         activity_groups = _build_activity_groups(activities, datasets)
     except ET.ParseError:
-        return JsonResponse({'error': 'Record XML is malformed'}, status=500)
-    return render(request, 'nexuslims_annotate/_panel.html', {
-        'data': data,
-        'datasets': datasets,
-        'activity_groups': activity_groups,
-        'record_id': record_id,
-    })
+        return JsonResponse({"error": "Record XML is malformed"}, status=500)
+    return render(
+        request,
+        "nexuslims_annotate/_panel.html",
+        {
+            "data": data,
+            "datasets": datasets,
+            "activity_groups": activity_groups,
+            "record_id": record_id,
+        },
+    )
 
 
 @login_required
@@ -622,83 +765,106 @@ def annotate_descriptions(request, record_id):
     try:
         data = data_api.get_by_id(record_id, request.user)
     except (DoesNotExist, ModelError):
-        return JsonResponse({'error': 'Record not found'}, status=404)
+        return JsonResponse({"error": "Record not found"}, status=404)
     try:
         check_can_write(data, request.user)
     except AccessControlError:
-        return JsonResponse({'error': 'Permission denied'}, status=403)
+        return JsonResponse({"error": "Permission denied"}, status=403)
     try:
         datasets = _parse_datasets(data.content)
     except ET.ParseError:
-        return JsonResponse({'error': 'Record XML is malformed'}, status=500)
-    return JsonResponse({
-        'datasets': [{'index': d['index'], 'name': d['name'], 'description': d['description']} for d in datasets]
-    })
+        return JsonResponse({"error": "Record XML is malformed"}, status=500)
+    return JsonResponse(
+        {
+            "datasets": [
+                {
+                    "index": d["index"],
+                    "name": d["name"],
+                    "description": d["description"],
+                }
+                for d in datasets
+            ]
+        }
+    )
 
 
 @login_required
 @require_POST
 def annotate_save_one(request, record_id):
     """AJAX POST: update a single dataset's description by index."""
-    raw_idx = request.POST.get('dataset_index')
+    raw_idx = request.POST.get("dataset_index")
     if raw_idx is None:
-        return JsonResponse({'error': 'dataset_index is required'}, status=400)
+        return JsonResponse({"error": "dataset_index is required"}, status=400)
     try:
         idx = int(raw_idx)
         if idx < 0:
-            return JsonResponse({'error': 'Invalid dataset_index'}, status=400)
+            return JsonResponse({"error": "Invalid dataset_index"}, status=400)
     except ValueError:
-        return JsonResponse({'error': 'dataset_index must be an integer'}, status=400)
+        return JsonResponse({"error": "dataset_index must be an integer"}, status=400)
     try:
-        description = request.POST.get('description', '').strip()
+        description = request.POST.get("description", "").strip()
         data = data_api.get_by_id(record_id, request.user)
         # Build full post_data from current state, replacing only the target index
         datasets = _parse_datasets(data.content)
         if idx >= len(datasets):
-            return JsonResponse({'error': 'dataset_index out of range'}, status=400)
-        post_data = {f'dataset_{d["index"]}_description': d['description'] for d in datasets}
-        post_data[f'dataset_{idx}_description'] = description
+            return JsonResponse({"error": "dataset_index out of range"}, status=400)
+        post_data = {
+            f"dataset_{d['index']}_description": d["description"] for d in datasets
+        }
+        post_data[f"dataset_{idx}_description"] = description
         data.content = _apply_descriptions(data.content, post_data)
         # Write permission is enforced by upsert (raises AccessControlError on failure).
         # Read-path views also call check_can_write explicitly to deny reads to write-only
         # users; write-path views rely on upsert instead.
         data_api.upsert(data, request)
-        return JsonResponse({'success': True})
+        return JsonResponse({"success": True})
     except (DoesNotExist, ModelError):
-        return JsonResponse({'error': 'Record not found'}, status=404)
+        return JsonResponse({"error": "Record not found"}, status=404)
     except AccessControlError as e:
-        return JsonResponse({'error': str(e)}, status=403)
+        return JsonResponse({"error": str(e)}, status=403)
     except Exception:
-        logger.exception('Error saving annotation for record %s dataset %s', record_id, raw_idx)
-        return JsonResponse({'error': 'Internal server error'}, status=500)
+        logger.exception(
+            "Error saving annotation for record %s dataset %s", record_id, raw_idx
+        )
+        return JsonResponse({"error": "Internal server error"}, status=500)
 
 
 @login_required
 @require_POST
 def annotate_save(request, record_id):
     """AJAX POST: update <description> elements, apply structural mutations, and save the record."""
-    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    is_ajax = request.headers.get("X-Requested-With") == "XMLHttpRequest"
     try:
         data = data_api.get_by_id(record_id, request.user)
 
         # Parse structural fields (new); fall back to empty defaults if absent
         try:
-            samples_raw = request.POST.get('samples')
+            samples_raw = request.POST.get("samples")
             samples = json.loads(samples_raw) if samples_raw is not None else None
-            deleted_seqnos = json.loads(request.POST.get('deleted_seqnos', '[]'))
-            new_activities = json.loads(request.POST.get('new_activities', '[]'))
-            activity_sample_ids = json.loads(request.POST.get('activity_sample_ids', '{}'))
+            deleted_seqnos = json.loads(request.POST.get("deleted_seqnos", "[]"))
+            new_activities = json.loads(request.POST.get("new_activities", "[]"))
+            activity_sample_ids = json.loads(
+                request.POST.get("activity_sample_ids", "{}")
+            )
         except (json.JSONDecodeError, ValueError) as e:
-            return JsonResponse({'error': f'Malformed JSON in structural fields: {e}'}, status=400)
+            return JsonResponse(
+                {"error": f"Malformed JSON in structural fields: {e}"}, status=400
+            )
 
         if samples is not None and not isinstance(samples, list):
-            return JsonResponse({'error': 'samples must be a JSON array'}, status=400)
+            return JsonResponse({"error": "samples must be a JSON array"}, status=400)
         if not isinstance(deleted_seqnos, list):
-            return JsonResponse({'error': 'deleted_seqnos must be a JSON array'}, status=400)
+            return JsonResponse(
+                {"error": "deleted_seqnos must be a JSON array"}, status=400
+            )
         if not isinstance(new_activities, list):
-            return JsonResponse({'error': 'new_activities must be a JSON array'}, status=400)
+            return JsonResponse(
+                {"error": "new_activities must be a JSON array"}, status=400
+            )
         if not isinstance(activity_sample_ids, dict):
-            return JsonResponse({'error': 'activity_sample_ids must be a JSON object'}, status=400)
+            return JsonResponse(
+                {"error": "activity_sample_ids must be a JSON object"}, status=400
+            )
 
         updated_xml = data.content
 
@@ -708,14 +874,16 @@ def annotate_save(request, record_id):
             updated_xml = _apply_title(updated_xml, new_title)
 
         # Parse moves before structural mutations so they can be passed in
-        moves_json = request.POST.get('moves', '[]')
+        moves_json = request.POST.get("moves", "[]")
         try:
             moves = json.loads(moves_json)
         except (json.JSONDecodeError, ValueError):
-            logger.warning('Ignoring malformed moves JSON for record %s: %r', record_id, moves_json)
+            logger.warning(
+                "Ignoring malformed moves JSON for record %s: %r", record_id, moves_json
+            )
             moves = []
         if not isinstance(moves, list):
-            logger.warning('moves is not a list for record %s, ignoring', record_id)
+            logger.warning("moves is not a list for record %s, ignoring", record_id)
             moves = []
 
         # Apply descriptions first: uses flat dataset indices from the original XML,
@@ -726,10 +894,14 @@ def annotate_save(request, record_id):
         # Passing moves here ensures activities emptied by moves can be deleted in the same save.
         try:
             updated_xml, seqno_mapping = _apply_activity_mutations(
-                updated_xml, deleted_seqnos, new_activities, activity_sample_ids, moves=moves
+                updated_xml,
+                deleted_seqnos,
+                new_activities,
+                activity_sample_ids,
+                moves=moves,
             )
         except ValueError as e:
-            return JsonResponse({'error': str(e)}, status=400)
+            return JsonResponse({"error": str(e)}, status=400)
 
         # Replace sample elements (only if the field was present in the POST)
         if samples is not None:
@@ -741,19 +913,23 @@ def annotate_save(request, record_id):
         data.content = updated_xml
         data_api.upsert(data, request)
         if is_ajax:
-            return JsonResponse({'success': True})
-        return redirect(reverse('core_main_app_data_detail') + f'?id={record_id}')
+            return JsonResponse({"success": True})
+        return redirect(reverse("core_main_app_data_detail") + f"?id={record_id}")
 
     except (DoesNotExist, ModelError):
         if is_ajax:
-            return JsonResponse({'error': 'Record not found'}, status=404)
-        raise Http404(f'Record {record_id} not found.')
+            return JsonResponse({"error": "Record not found"}, status=404)
+        raise Http404(f"Record {record_id} not found.")
     except AccessControlError as e:
         if is_ajax:
-            return JsonResponse({'error': str(e)}, status=403)
-        return redirect(reverse('nexuslims_annotate_record', args=[record_id]) + '?error=1')
+            return JsonResponse({"error": str(e)}, status=403)
+        return redirect(
+            reverse("nexuslims_annotate_record", args=[record_id]) + "?error=1"
+        )
     except Exception:
-        logger.exception('Error saving annotations for record %s', record_id)
+        logger.exception("Error saving annotations for record %s", record_id)
         if is_ajax:
-            return JsonResponse({'error': 'Internal server error'}, status=500)
-        return redirect(reverse('nexuslims_annotate_record', args=[record_id]) + '?error=1')
+            return JsonResponse({"error": "Internal server error"}, status=500)
+        return redirect(
+            reverse("nexuslims_annotate_record", args=[record_id]) + "?error=1"
+        )

--- a/nexuslims_overrides/__init__.py
+++ b/nexuslims_overrides/__init__.py
@@ -11,4 +11,4 @@ Design Pattern:
 - Custom template tags for reusable components
 """
 
-default_app_config = 'nexuslims_overrides.apps.NexusLIMSOverridesConfig'
+default_app_config = "nexuslims_overrides.apps.NexusLIMSOverridesConfig"

--- a/nexuslims_overrides/apps.py
+++ b/nexuslims_overrides/apps.py
@@ -1,16 +1,17 @@
 """
 NexusLIMS Overrides App Configuration
 """
+
 from django.apps import AppConfig
 
 
 class NexusLIMSOverridesConfig(AppConfig):
     """Configuration for NexusLIMS customization app."""
-    
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'nexuslims_overrides'
-    verbose_name = 'NexusLIMS Customizations'
-    
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "nexuslims_overrides"
+    verbose_name = "NexusLIMS Customizations"
+
     def ready(self):
         """
         Called when Django starts.

--- a/nexuslims_overrides/context_processors.py
+++ b/nexuslims_overrides/context_processors.py
@@ -4,6 +4,7 @@ Context processors for NexusLIMS customizations.
 These functions add variables to the template context for all templates.
 Register in settings.py under TEMPLATES['OPTIONS']['context_processors'].
 """
+
 from django.conf import settings
 
 
@@ -21,13 +22,19 @@ def nexuslims_settings(request):
         {{ NX_FOOTER_LINK }}
     """
     return {
-        'NX_DOCUMENTATION_LINK': getattr(settings, 'NX_DOCUMENTATION_LINK', ''),
-        'NX_HOMEPAGE_TEXT': getattr(settings, 'NX_HOMEPAGE_TEXT', ''),
-        'NX_CUSTOM_TITLE': getattr(settings, 'CUSTOM_TITLE', 'Welcome to NexusLIMS!'),
-        'NX_HOMEPAGE_LOGO': getattr(settings, 'NX_HOMEPAGE_LOGO', 'nexuslims/img/logo_stacked_modern.png'),
-        'NX_NAV_LOGO': getattr(settings, 'NX_NAV_LOGO', 'nexuslims/img/logo_horizontal_light.png'),
-        'NX_FOOTER_LOGO': getattr(settings, 'NX_FOOTER_LOGO', 'nexuslims/img/datasophos_logo.png'),
-        'NX_FOOTER_LINK': getattr(settings, 'NX_FOOTER_LINK', 'https://datasophos.co'),
+        "NX_DOCUMENTATION_LINK": getattr(settings, "NX_DOCUMENTATION_LINK", ""),
+        "NX_HOMEPAGE_TEXT": getattr(settings, "NX_HOMEPAGE_TEXT", ""),
+        "NX_CUSTOM_TITLE": getattr(settings, "CUSTOM_TITLE", "Welcome to NexusLIMS!"),
+        "NX_HOMEPAGE_LOGO": getattr(
+            settings, "NX_HOMEPAGE_LOGO", "nexuslims/img/logo_stacked_modern.png"
+        ),
+        "NX_NAV_LOGO": getattr(
+            settings, "NX_NAV_LOGO", "nexuslims/img/logo_horizontal_light.png"
+        ),
+        "NX_FOOTER_LOGO": getattr(
+            settings, "NX_FOOTER_LOGO", "nexuslims/img/datasophos_logo.png"
+        ),
+        "NX_FOOTER_LINK": getattr(settings, "NX_FOOTER_LINK", "https://datasophos.co"),
     }
 
 
@@ -41,15 +48,16 @@ def nexuslims_features(request):
         {% endif %}
     """
     return {
-        'NX_ENABLE_TUTORIALS': getattr(settings, 'NX_ENABLE_TUTORIALS', True),
-        'NX_ENABLE_ANNOTATOR': getattr(settings, 'NX_ENABLE_ANNOTATOR', True),
-        'IS_PUBLIC_DEMO': getattr(settings, 'IS_PUBLIC_DEMO', False),
+        "NX_ENABLE_TUTORIALS": getattr(settings, "NX_ENABLE_TUTORIALS", True),
+        "NX_ENABLE_ANNOTATOR": getattr(settings, "NX_ENABLE_ANNOTATOR", True),
+        "IS_PUBLIC_DEMO": getattr(settings, "IS_PUBLIC_DEMO", False),
     }
+
 
 def nexuslims_colors(request):
     """
     Make NexusLIMS theme colors available for CSS custom property overrides.
     """
     return {
-        'NX_THEME_COLORS': getattr(settings, 'NX_THEME_COLORS', {}),
+        "NX_THEME_COLORS": getattr(settings, "NX_THEME_COLORS", {}),
     }

--- a/nexuslims_overrides/menus.py
+++ b/nexuslims_overrides/menus.py
@@ -34,8 +34,8 @@ Menu.add_item(
         "Browse and Search Records",
         reverse("core_explore_keyword_app_search"),
         icon="search",
-        iconClass="fas"
-    )
+        iconClass="fas",
+    ),
 )
 
 # Custom menu links - configurable via settings
@@ -47,11 +47,15 @@ Menu.add_item(
 # ]
 from django.conf import settings
 
-custom_links = getattr(settings, 'NX_CUSTOM_MENU_LINKS', [
-    {"title": "LINK 1", "url": "https://example.com", "icon": "fish"},
-    {"title": "LINK 2", "url": "https://example.com", "icon": "fish"},
-    {"title": "LINK 3", "url": "https://example.com", "icon": "users"},
-])
+custom_links = getattr(
+    settings,
+    "NX_CUSTOM_MENU_LINKS",
+    [
+        {"title": "LINK 1", "url": "https://example.com", "icon": "fish"},
+        {"title": "LINK 2", "url": "https://example.com", "icon": "fish"},
+        {"title": "LINK 3", "url": "https://example.com", "icon": "users"},
+    ],
+)
 
 for link in custom_links:
     Menu.add_item(
@@ -60,21 +64,17 @@ for link in custom_links:
             link.get("title", "Link"),
             link.get("url", "#"),
             icon=link.get("icon", "link"),
-            iconClass=link.get("iconClass", "fas")
-        )
+            iconClass=link.get("iconClass", "fas"),
+        ),
     )
 
 # Tutorial menu item - conditional on NX_ENABLE_TUTORIALS setting
-if getattr(settings, 'NX_ENABLE_TUTORIALS', True):
+if getattr(settings, "NX_ENABLE_TUTORIALS", True):
     Menu.add_item(
         "nodropdown",
         MenuItem(
-            "Tutorial",
-            "#",
-            icon="question-circle",
-            iconClass="fas",
-            id="menu-tutorial"
-        )
+            "Tutorial", "#", icon="question-circle", iconClass="fas", id="menu-tutorial"
+        ),
     )
 
 # ============================================================================
@@ -87,7 +87,7 @@ Menu.add_item(
         "My Workspaces",
         reverse("core_dashboard_workspaces"),
         icon="folder-open",
-        iconClass="fas"
+        iconClass="fas",
     ),
 )
 
@@ -97,7 +97,7 @@ Menu.add_item(
         "My {0}s".format(get_data_label().title()),
         reverse("core_dashboard_records"),
         icon="file-alt",
-        iconClass="fas"
+        iconClass="fas",
     ),
 )
 
@@ -107,27 +107,21 @@ Menu.add_item(
         "My {0}s".format(get_form_label().title()),
         reverse("core_dashboard_forms"),
         icon="file-alt",
-        iconClass="fas"
+        iconClass="fas",
     ),
 )
 
 Menu.add_item(
     "dashboard",
     MenuItem(
-        "My Files",
-        reverse("core_dashboard_files"),
-        icon="file-alt",
-        iconClass="fas"
-    )
+        "My Files", reverse("core_dashboard_files"), icon="file-alt", iconClass="fas"
+    ),
 )
 
 Menu.add_item(
     "dashboard",
     MenuItem(
-        "My Queries",
-        reverse("core_dashboard_queries"),
-        icon="search",
-        iconClass="fas"
+        "My Queries", reverse("core_dashboard_queries"), icon="search", iconClass="fas"
     ),
 )
 
@@ -137,26 +131,21 @@ Menu.add_item(
 
 # Get documentation link from settings
 from django.conf import settings
-DOCUMENTATION_LINK = getattr(settings, 'NX_DOCUMENTATION_LINK', 'https://example.com')
+
+DOCUMENTATION_LINK = getattr(settings, "NX_DOCUMENTATION_LINK", "https://example.com")
 
 Menu.add_item(
     "help",
     MenuItem(
-        "NexusLIMS Documentation",
-        DOCUMENTATION_LINK,
-        icon="book",
-        iconClass="fas"
-    )
+        "NexusLIMS Documentation", DOCUMENTATION_LINK, icon="book", iconClass="fas"
+    ),
 )
 
 Menu.add_item(
     "help",
     MenuItem(
-        "API Documentation",
-        reverse("swagger_view"),
-        icon="cogs",
-        iconClass="fas"
-    )
+        "API Documentation", reverse("swagger_view"), icon="cogs", iconClass="fas"
+    ),
 )
 
 # ============================================================================

--- a/nexuslims_overrides/middleware.py
+++ b/nexuslims_overrides/middleware.py
@@ -22,13 +22,19 @@ class DemoAutoLoginMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if getattr(settings, 'IS_PUBLIC_DEMO', False) and not request.user.is_authenticated:
+        if (
+            getattr(settings, "IS_PUBLIC_DEMO", False)
+            and not request.user.is_authenticated
+        ):
             if request.path not in EXCLUDED_PATHS:
                 from django.contrib.auth import get_user_model
+
                 User = get_user_model()
 
                 username = request.GET.get(DEMO_USER_PARAM, DEMO_DEFAULT_USER)
-                demo_usernames = getattr(settings, 'DEMO_USERNAMES', [DEMO_DEFAULT_USER])
+                demo_usernames = getattr(
+                    settings, "DEMO_USERNAMES", [DEMO_DEFAULT_USER]
+                )
                 if username not in demo_usernames:
                     username = DEMO_DEFAULT_USER
 
@@ -37,7 +43,7 @@ class DemoAutoLoginMiddleware:
                     login(
                         request,
                         user,
-                        backend='django.contrib.auth.backends.ModelBackend',
+                        backend="django.contrib.auth.backends.ModelBackend",
                     )
 
         return self.get_response(request)

--- a/nexuslims_overrides/migrations/0001_create_search_operators.py
+++ b/nexuslims_overrides/migrations/0001_create_search_operators.py
@@ -6,37 +6,36 @@ from django.db import migrations
 def create_instrument_pid_operator(apps, schema_editor):
     """Create the instrument-pid search operator for clickable badge filtering."""
     # Get the SearchOperator model
-    SearchOperator = apps.get_model('core_explore_keyword_app', 'SearchOperator')
+    SearchOperator = apps.get_model("core_explore_keyword_app", "SearchOperator")
 
     # Check if operator already exists
-    if SearchOperator.objects.filter(name='instrument-pid').exists():
+    if SearchOperator.objects.filter(name="instrument-pid").exists():
         print("  → Search operator 'instrument-pid' already exists, skipping...")
         return
 
     # Create the operator
     SearchOperator.objects.create(
-        name='instrument-pid',
-        xpath_list=['/nx:Experiment/nx:summary/nx:instrument/@pid'],
-        dot_notation_list=['Experiment.summary.instrument.@pid']
+        name="instrument-pid",
+        xpath_list=["/nx:Experiment/nx:summary/nx:instrument/@pid"],
+        dot_notation_list=["Experiment.summary.instrument.@pid"],
     )
     print("  ✓ Created search operator 'instrument-pid'")
 
 
 def remove_instrument_pid_operator(apps, schema_editor):
     """Remove the instrument-pid search operator (for migration rollback)."""
-    SearchOperator = apps.get_model('core_explore_keyword_app', 'SearchOperator')
+    SearchOperator = apps.get_model("core_explore_keyword_app", "SearchOperator")
 
     # Delete the operator if it exists
-    deleted_count, _ = SearchOperator.objects.filter(name='instrument-pid').delete()
+    deleted_count, _ = SearchOperator.objects.filter(name="instrument-pid").delete()
 
     if deleted_count > 0:
-        print(f"  ✓ Removed search operator 'instrument-pid'")
+        print("  ✓ Removed search operator 'instrument-pid'")
     else:
         print("  → Search operator 'instrument-pid' not found, nothing to remove")
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         # This migration depends on core_explore_keyword_app being installed
         # If core_explore_keyword_app has migrations, reference the latest one here
@@ -45,7 +44,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            create_instrument_pid_operator,
-            reverse_code=remove_instrument_pid_operator
+            create_instrument_pid_operator, reverse_code=remove_instrument_pid_operator
         ),
     ]

--- a/nexuslims_overrides/signals.py
+++ b/nexuslims_overrides/signals.py
@@ -14,23 +14,27 @@ def grant_anonymous_explore_permission(sender, **kwargs):
     This runs after migrations complete, ensuring the permission exists.
     """
     # Only run for our app or for core_explore_keyword_app
-    if sender.name not in ['nexuslims_overrides', 'core_explore_keyword_app']:
+    if sender.name not in ["nexuslims_overrides", "core_explore_keyword_app"]:
         return
 
     from django.contrib.auth.models import Group, Permission
 
     try:
         # Get or create the anonymous group
-        anonymous_group, created = Group.objects.get_or_create(name='anonymous')
+        anonymous_group, created = Group.objects.get_or_create(name="anonymous")
 
         # Get the permission (may not exist yet if this is running for nexuslims_overrides)
         try:
-            permission = Permission.objects.get(codename='access_explore_keyword')
+            permission = Permission.objects.get(codename="access_explore_keyword")
 
             # Only add if not already there
-            if not anonymous_group.permissions.filter(codename='access_explore_keyword').exists():
+            if not anonymous_group.permissions.filter(
+                codename="access_explore_keyword"
+            ).exists():
                 anonymous_group.permissions.add(permission)
-                print(f"✓ Granted 'access_explore_keyword' permission to 'anonymous' group")
+                print(
+                    "✓ Granted 'access_explore_keyword' permission to 'anonymous' group"
+                )
 
         except Permission.DoesNotExist:
             # Permission doesn't exist yet - will be handled when core_explore_keyword_app migrates

--- a/nexuslims_overrides/templatetags/nexuslims_templatetags.py
+++ b/nexuslims_overrides/templatetags/nexuslims_templatetags.py
@@ -6,13 +6,16 @@ Usage in templates:
     {% nexuslims_custom_toolbar data %}
     {{ value|nexuslims_format }}
 """
+
 from django import template
 from django.utils.safestring import mark_safe
 
 register = template.Library()
 
 
-@register.inclusion_tag('nexuslims_overrides/fragments/custom_toolbar.html', takes_context=True)
+@register.inclusion_tag(
+    "nexuslims_overrides/fragments/custom_toolbar.html", takes_context=True
+)
 def nexuslims_custom_toolbar(context, data=None):
     """
     (Claude hallucination)
@@ -22,13 +25,15 @@ def nexuslims_custom_toolbar(context, data=None):
         {% nexuslims_custom_toolbar data %}
     """
     return {
-        'data': data,
-        'user': context.get('user'),
-        'request': context.get('request'),
+        "data": data,
+        "user": context.get("user"),
+        "request": context.get("request"),
     }
 
 
-@register.inclusion_tag('nexuslims_overrides/fragments/download_buttons.html', takes_context=True)
+@register.inclusion_tag(
+    "nexuslims_overrides/fragments/download_buttons.html", takes_context=True
+)
 def nexuslims_download_buttons(context, data):
     """
     (Claude hallucination)
@@ -38,8 +43,8 @@ def nexuslims_download_buttons(context, data):
         {% nexuslims_download_buttons data %}
     """
     return {
-        'data': data,
-        'user': context.get('user'),
+        "data": data,
+        "user": context.get("user"),
     }
 
 
@@ -54,11 +59,11 @@ def nexuslims_instrument_color(instrument_pid):
     """
     # This can be moved to settings or a database model
     INSTRUMENT_COLORS = {
-        '643d9ac1-d0a5-4830-b832-17546f67942a': 'primary',
-        '643d8a1e-e1e9-4bf4-b825-38b56c2e47d9': 'success',
+        "643d9ac1-d0a5-4830-b832-17546f67942a": "primary",
+        "643d8a1e-e1e9-4bf4-b825-38b56c2e47d9": "success",
         # Add more as needed
     }
-    return INSTRUMENT_COLORS.get(str(instrument_pid), 'secondary')
+    return INSTRUMENT_COLORS.get(str(instrument_pid), "secondary")
 
 
 @register.filter

--- a/nexuslims_overrides/templatetags/nexuslims_xsl_transform.py
+++ b/nexuslims_overrides/templatetags/nexuslims_xsl_transform.py
@@ -56,8 +56,8 @@ def render_xml_as_html_list(*args, **kwargs):
 
     """
     # Format detail_url in-place as XSLT string parameter (wrapped in quotes)
-    if 'detail_url' in kwargs:
-        kwargs['detail_url'] = f"\"{kwargs['detail_url']}\""
+    if "detail_url" in kwargs:
+        kwargs["detail_url"] = f'"{kwargs["detail_url"]}"'
 
     return _render_xml_as_html(XSLType.type_list, *args, **kwargs)
 
@@ -81,19 +81,20 @@ def render_xml_as_html_detail(*args, **kwargs):
 
     """
     # Format xmlName as XSLT string parameter (wrapped in quotes)
-    if 'xmlName' in kwargs:
-        kwargs['xmlName'] = f"\"{kwargs['xmlName']}\""
+    if "xmlName" in kwargs:
+        kwargs["xmlName"] = f'"{kwargs["xmlName"]}"'
 
     # Add data ID if provided
-    if 'data_id' in kwargs:
-        kwargs['dataId'] = f"\"{kwargs.pop('data_id')}\""
+    if "data_id" in kwargs:
+        kwargs["dataId"] = f'"{kwargs.pop("data_id")}"'
 
     # Add permission URL if request is provided
-    if 'request' in kwargs:
+    if "request" in kwargs:
         try:
             from django.urls import reverse
-            permission_url = reverse('core_main_app_rest_data_permissions')
-            kwargs['permissionUrl'] = f"\"{permission_url}\""
+
+            permission_url = reverse("core_main_app_rest_data_permissions")
+            kwargs["permissionUrl"] = f'"{permission_url}"'
         except Exception:
             # If URL reversal fails, don't add permission URL
             pass
@@ -127,20 +128,22 @@ def _render_xml_as_html(xslt_type, *args, **kwargs):
     request = kwargs.pop("request", None)
 
     # Add instrument color mappings from Django settings
-    if hasattr(settings, 'NX_INSTRUMENT_COLOR_MAPPINGS'):
+    if hasattr(settings, "NX_INSTRUMENT_COLOR_MAPPINGS"):
         color_mappings = settings.NX_INSTRUMENT_COLOR_MAPPINGS
         # Convert the Python dict to a format that XSLT can parse
         # Create the format XSLT expects: '"pid1":"color1","pid2":"color2"'
         # Wrap the entire string in single quote to make it a valid XPath string literal
-        xslt_format = ",".join([f"\"{pid}\":\"{color}\"" for pid, color in color_mappings.items()])
-        kwargs['instrColorMappings'] = f"'{xslt_format}'"
+        xslt_format = ",".join(
+            [f'"{pid}":"{color}"' for pid, color in color_mappings.items()]
+        )
+        kwargs["instrColorMappings"] = f"'{xslt_format}'"
 
     # Add max dataset display count from Django settings
-    if hasattr(settings, 'NX_MAX_DATASET_DISPLAY_COUNT'):
+    if hasattr(settings, "NX_MAX_DATASET_DISPLAY_COUNT"):
         try:
             max_count = int(settings.NX_MAX_DATASET_DISPLAY_COUNT)
             xslt_format = f'"{max_count}"'
-            kwargs['maxDatasetCount'] = xslt_format
+            kwargs["maxDatasetCount"] = xslt_format
         except ValueError as e:
             print(f"WARNING: Could not parse NX_MAX_DATASET_DISPLAY_COUNT setting: {e}")
 
@@ -157,33 +160,23 @@ def _render_xml_as_html(xslt_type, *args, **kwargs):
     try:
         try:
             if xslt_type not in (XSLType.type_list, XSLType.type_detail):
-                raise Exception(
-                    "XSLT Type unknown. Default xslt will be used."
-                )
+                raise Exception("XSLT Type unknown. Default xslt will be used.")
             if xsl_transform_id:
-                xsl_transformation = xsl_transformation_api.get_by_id(
-                    xsl_transform_id
-                )
+                xsl_transformation = xsl_transformation_api.get_by_id(xsl_transform_id)
             elif template_id or template_hash:
                 if template_id:
                     template_xsl_rendering = (
-                        template_xsl_rendering_api.get_by_template_id(
-                            template_id
-                        )
+                        template_xsl_rendering_api.get_by_template_id(template_id)
                     )
                 else:
                     template_xsl_rendering = (
-                        template_xsl_rendering_api.get_by_template_hash(
-                            template_hash
-                        )
+                        template_xsl_rendering_api.get_by_template_hash(template_hash)
                     )
 
                 if xslt_type == XSLType.type_list:
                     xsl_transformation = template_xsl_rendering.list_xslt
                 else:
-                    xsl_transformation = (
-                        template_xsl_rendering.default_detail_xslt
-                    )
+                    xsl_transformation = template_xsl_rendering.default_detail_xslt
             else:
                 raise Exception(
                     "No template information provided. Default xslt will be used."

--- a/nexuslims_overrides/urls.py
+++ b/nexuslims_overrides/urls.py
@@ -3,10 +3,11 @@ NexusLIMS URL overrides.
 
 These URLs override the default MDCS URLs to use custom NexusLIMS views.
 """
+
 from django.urls import path
 from . import views
 
 urlpatterns = [
     # Override the tiles view from mdcs_home
-    path('home/tiles', views.tiles, name='core_main_app_homepage_tiles'),
+    path("home/tiles", views.tiles, name="core_main_app_homepage_tiles"),
 ]

--- a/nexuslims_overrides/views.py
+++ b/nexuslims_overrides/views.py
@@ -6,6 +6,7 @@ These views override or extend the default MDCS views.
 File overrides:
 - tiles() -> overrides mdcs_home/views.py::tiles()
 """
+
 import logging
 
 from django.conf import settings
@@ -39,7 +40,7 @@ def tiles(request):
             "link": reverse("core_explore_keyword_app_search"),
             "title": "Browse and Search Records",
             "text": "Click here to explore the NexusLIMS record repository",
-            "id": "app_search"
+            "id": "app_search",
         }
         context["tiles"].append(explore_keywords_tile)
 
@@ -50,7 +51,7 @@ def tiles(request):
             "link": reverse("core_curate_index"),
             "title": "Create a new record",
             "text": "Click here to upload a record manually or build a record from scratch",
-            "id": "curator"
+            "id": "curator",
         }
         # Disabled for NexusLIMS - records are auto-generated
         # Uncomment to enable manual record creation:

--- a/nexuslims_overrides/xml.py
+++ b/nexuslims_overrides/xml.py
@@ -1,6 +1,7 @@
-""" Xml utils for the core applications
-    Override of some functions in core_main_app.utils.xml
+"""Xml utils for the core applications
+Override of some functions in core_main_app.utils.xml
 """
+
 import logging
 import traceback
 
@@ -10,6 +11,7 @@ import core_main_app.commons.exceptions as exceptions
 from xml_utils.xsd_tree.xsd_tree import XSDTree
 
 logger = logging.getLogger(__name__)
+
 
 def xsl_transform(xml_string, xslt_string, **kwargs):
     """Apply transformation to xml, allowing for parameters to the XSLT
@@ -29,17 +31,19 @@ def xsl_transform(xml_string, xslt_string, **kwargs):
         xsd_tree = XSDTree.build_tree(xml_string)
 
         # Get the XSLT transformation and transform the XSD
-        transform = XSDTree.transform_to_xslt(xslt_tree)   # etree.XSLT object
+        transform = XSDTree.transform_to_xslt(xslt_tree)  # etree.XSLT object
         transformed_tree = transform(xsd_tree, **kwargs)
         return str(transformed_tree)
     except Exception as e:
         for error in transform.error_log:
             print(f"LXML ERROR: {error}")
         traceback.print_exc()
-        raise exceptions.CoreError("An unexpected exception happened while transforming the XML") from e
+        raise exceptions.CoreError(
+            "An unexpected exception happened while transforming the XML"
+        ) from e
     finally:
         # print messages from transformation, if configured
-        if hasattr(settings, 'NX_XSLT_DEBUG'):
+        if hasattr(settings, "NX_XSLT_DEBUG"):
             if settings.NX_XSLT_DEBUG:
                 if transform.error_log:
                     print("NX_XSLT_DEBUG output:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexuslims-cdcs"
-version = "3.20.0+nx0"
+version = "3.21.0+nx0"
 description = "NexusLIMS-CDCS: An automated laboratory information management system for microscopy data management"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -25,28 +25,28 @@ dependencies = [
     # - Session storage that survives application restarts
     # Required by: config/settings/prod_settings.py
     "django-redis",
-    # CDCS/MDCS core packages - all pinned to 2.20.* for compatibility
-    "core_main_app[auth]==2.20.*",
-    "core_composer_app==2.20.*",
-    "core_curate_app==2.20.*",
-    "core_dashboard_common_app==2.20.*",
-    "core_dashboard_app==2.20.*",
-    "core_explore_example_app==2.20.*",
-    "core_explore_keyword_app==2.20.*",
-    "core_explore_federated_search_app==2.20.*",
-    "core_exporters_app==2.20.*",
-    "core_federated_search_app==2.20.*",
-    "core_website_app==2.20.*",
-    "core_module_blob_host_app==2.20.*",
-    "core_module_remote_blob_host_app==2.20.*",
-    "core_module_advanced_blob_host_app==2.20.*",
-    "core_module_excel_uploader_app==2.20.*",
-    "core_module_periodic_table_app==2.20.*",
-    "core_module_chemical_composition_app==2.20.*",
-    "core_module_chemical_composition_simple_app==2.20.*",
-    "core_module_text_area_app==2.20.*",
-    "core_file_preview_app==2.20.*",
-    "core_linked_records_app==2.20.*",
+    # CDCS/MDCS core packages - all pinned to 2.21.* for compatibility
+    "core_main_app[auth]==2.21.*",
+    "core_composer_app==2.21.*",
+    "core_curate_app==2.21.*",
+    "core_dashboard_common_app==2.21.*",
+    "core_dashboard_app==2.21.*",
+    "core_explore_example_app==2.21.*",
+    "core_explore_keyword_app==2.21.*",
+    "core_explore_federated_search_app==2.21.*",
+    "core_exporters_app==2.21.*",
+    "core_federated_search_app==2.21.*",
+    "core_website_app==2.21.*",
+    "core_module_blob_host_app==2.21.*",
+    "core_module_remote_blob_host_app==2.21.*",
+    "core_module_advanced_blob_host_app==2.21.*",
+    "core_module_excel_uploader_app==2.21.*",
+    "core_module_periodic_table_app==2.21.*",
+    "core_module_chemical_composition_app==2.21.*",
+    "core_module_chemical_composition_simple_app==2.21.*",
+    "core_module_text_area_app==2.21.*",
+    "core_file_preview_app==2.21.*",
+    "core_linked_records_app==2.21.*",
     # Production server packages
     "psycopg2-binary",       # PostgreSQL adapter
     "uwsgi",                 # Application server

--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-""" Run tests
-"""
+"""Run tests"""
+
 import os
 import sys
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3071,3 +3071,11 @@
             }
 
 	}
+
+/* Fix Monaco editor button styling in text search (upstream fix from MDCS 3.21.0) */
+.monaco-editor .button {
+    background-color: transparent !important;
+    background-image: none !important;
+    min-width: unset !important;
+    color: inherit !important;
+}

--- a/tests/test_annotator.py
+++ b/tests/test_annotator.py
@@ -1,8 +1,8 @@
 """Unit tests for nexuslims_annotate helper functions and views."""
+
 import json
 import os
 import xml.etree.ElementTree as ET
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
@@ -90,7 +90,8 @@ def _dump_activity_el(act):
     setup = act.find(_t("setup"))
     setup_params = (
         {p.get("name"): p.text for p in setup.findall(_t("param"))}
-        if setup is not None else {}
+        if setup is not None
+        else {}
     )
     print(f"  activity seqno={seqno}: {len(datasets)} dataset(s), setup={setup_params}")
     for ds in datasets:
@@ -242,6 +243,7 @@ _NO_SAMPLES_XML = f"""\
 # _parse_datasets
 # ===========================================================================
 
+
 class ParseDatasetsTests(SimpleTestCase):
     def test_returns_correct_total_count(self):
         self.assertEqual(len(_parse_datasets(_TWO_ACTIVITY_XML)), 4)
@@ -252,7 +254,9 @@ class ParseDatasetsTests(SimpleTestCase):
 
     def test_names_match_xml_order(self):
         names = [d["name"] for d in _parse_datasets(_TWO_ACTIVITY_XML)]
-        self.assertEqual(names, ["image_001.dm3", "image_002.dm3", "image_003.dm3", "image_004.dm3"])
+        self.assertEqual(
+            names, ["image_001.dm3", "image_002.dm3", "image_003.dm3", "image_004.dm3"]
+        )
 
     def test_description_returned_when_present(self):
         ds = _parse_datasets(_TWO_ACTIVITY_XML)
@@ -271,9 +275,13 @@ class ParseDatasetsTests(SimpleTestCase):
         self.assertEqual(ds[3]["activity_seqno"], "1")
 
     def test_preview_url_built_from_env_var(self):
-        with patch.dict(os.environ, {"XSLT_PREVIEW_BASE_URL": "https://cdn.example.com"}):
+        with patch.dict(
+            os.environ, {"XSLT_PREVIEW_BASE_URL": "https://cdn.example.com"}
+        ):
             ds = _parse_datasets(_TWO_ACTIVITY_XML)
-        self.assertEqual(ds[0]["preview_url"], "https://cdn.example.com/previews/image_001.png")
+        self.assertEqual(
+            ds[0]["preview_url"], "https://cdn.example.com/previews/image_001.png"
+        )
 
     def test_preview_url_none_when_no_preview_element(self):
         ds = _parse_datasets(_TWO_ACTIVITY_XML)
@@ -288,6 +296,7 @@ class ParseDatasetsTests(SimpleTestCase):
 # ===========================================================================
 # _parse_activities
 # ===========================================================================
+
 
 class ParseActivitiesTests(SimpleTestCase):
     def test_returns_correct_count(self):
@@ -314,17 +323,18 @@ class ParseActivitiesTests(SimpleTestCase):
 
     def test_sample_id_returned_when_present(self):
         acts = _parse_activities(_WITH_SAMPLES_XML)
-        self.assertEqual(acts[0]['sample_id'], 'steel-alloy-a')
+        self.assertEqual(acts[0]["sample_id"], "steel-alloy-a")
 
     def test_sample_id_empty_string_when_absent(self):
         acts = _parse_activities(_NO_SAMPLES_XML)
-        self.assertEqual(acts[0]['sample_id'], '')
-        self.assertEqual(acts[1]['sample_id'], '')
+        self.assertEqual(acts[0]["sample_id"], "")
+        self.assertEqual(acts[1]["sample_id"], "")
 
 
 # ===========================================================================
 # _parse_samples
 # ===========================================================================
+
 
 class ParseSamplesTests(SimpleTestCase):
     def test_returns_correct_count(self):
@@ -335,47 +345,48 @@ class ParseSamplesTests(SimpleTestCase):
 
     def test_id_attribute_captured(self):
         samples = _parse_samples(_WITH_SAMPLES_XML)
-        self.assertEqual(samples[0]['id'], 'steel-alloy-a')
-        self.assertEqual(samples[1]['id'], 'brass-ref')
+        self.assertEqual(samples[0]["id"], "steel-alloy-a")
+        self.assertEqual(samples[1]["id"], "brass-ref")
 
     def test_name_captured(self):
         samples = _parse_samples(_WITH_SAMPLES_XML)
-        self.assertEqual(samples[0]['name'], 'Steel Alloy A')
+        self.assertEqual(samples[0]["name"], "Steel Alloy A")
 
     def test_description_captured(self):
         samples = _parse_samples(_WITH_SAMPLES_XML)
-        self.assertEqual(samples[0]['description'], 'High-carbon steel reference')
+        self.assertEqual(samples[0]["description"], "High-carbon steel reference")
 
     def test_description_empty_string_when_absent(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
         xml = f'<Experiment xmlns="{NS}"><sample id="x"><name>X</name></sample></Experiment>'
         samples = _parse_samples(xml)
-        self.assertEqual(samples[0]['description'], '')
+        self.assertEqual(samples[0]["description"], "")
 
     def test_elements_list_returned(self):
         samples = _parse_samples(_WITH_SAMPLES_XML)
-        self.assertEqual(samples[0]['elements'], ['Fe', 'C', 'Cr', 'Ni'])
+        self.assertEqual(samples[0]["elements"], ["Fe", "C", "Cr", "Ni"])
 
     def test_elements_empty_list_when_absent(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
         xml = f'<Experiment xmlns="{NS}"><sample id="x"><name>X</name></sample></Experiment>'
         samples = _parse_samples(xml)
-        self.assertEqual(samples[0]['elements'], [])
+        self.assertEqual(samples[0]["elements"], [])
 
     def test_ref_attribute_captured(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
         xml = f'<Experiment xmlns="{NS}"><sample id="x" ref="https://doi.org/10.1/abc"><name>X</name></sample></Experiment>'
         samples = _parse_samples(xml)
-        self.assertEqual(samples[0]['ref'], 'https://doi.org/10.1/abc')
+        self.assertEqual(samples[0]["ref"], "https://doi.org/10.1/abc")
 
     def test_ref_empty_string_when_absent(self):
         samples = _parse_samples(_WITH_SAMPLES_XML)
-        self.assertEqual(samples[0]['ref'], '')
+        self.assertEqual(samples[0]["ref"], "")
 
 
 # ===========================================================================
 # _apply_samples
 # ===========================================================================
+
 
 class ApplySamplesTests(SimpleTestCase):
     def _get_samples(self, xml_str):
@@ -383,12 +394,18 @@ class ApplySamplesTests(SimpleTestCase):
 
     def test_replaces_existing_samples_with_new_list(self):
         new_samples = [
-            {'id': 'new-s', 'name': 'New Sample', 'description': 'desc', 'notes': '', 'elements': ['Au']},
+            {
+                "id": "new-s",
+                "name": "New Sample",
+                "description": "desc",
+                "notes": "",
+                "elements": ["Au"],
+            },
         ]
         result = _apply_samples(_WITH_SAMPLES_XML, new_samples)
         samples = self._get_samples(result)
         self.assertEqual(len(samples), 1)
-        self.assertEqual(samples[0]['name'], 'New Sample')
+        self.assertEqual(samples[0]["name"], "New Sample")
 
     def test_empty_list_removes_all_samples(self):
         result = _apply_samples(_WITH_SAMPLES_XML, [])
@@ -396,50 +413,70 @@ class ApplySamplesTests(SimpleTestCase):
 
     def test_adds_samples_when_none_existed(self):
         new_samples = [
-            {'id': 'added', 'name': 'Added', 'description': '', 'notes': '', 'elements': []},
+            {
+                "id": "added",
+                "name": "Added",
+                "description": "",
+                "notes": "",
+                "elements": [],
+            },
         ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         samples = self._get_samples(result)
         self.assertEqual(len(samples), 1)
-        self.assertEqual(samples[0]['id'], 'added')
+        self.assertEqual(samples[0]["id"], "added")
 
     def test_id_attribute_set(self):
-        new_samples = [{'id': 'my-id', 'name': 'S', 'description': '', 'notes': '', 'elements': []}]
+        new_samples = [
+            {"id": "my-id", "name": "S", "description": "", "notes": "", "elements": []}
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP = {'nx': NS}
-        s = root.find('nx:sample', NS_MAP)
-        self.assertEqual(s.get('id'), 'my-id')
+        NS_MAP = {"nx": NS}
+        s = root.find("nx:sample", NS_MAP)
+        self.assertEqual(s.get("id"), "my-id")
 
     def test_elements_written_as_child_tags(self):
-        new_samples = [{'id': 's', 'name': 'S', 'description': '', 'notes': '', 'elements': ['Fe', 'Ni']}]
+        new_samples = [
+            {
+                "id": "s",
+                "name": "S",
+                "description": "",
+                "notes": "",
+                "elements": ["Fe", "Ni"],
+            }
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP = {'nx': NS}
-        s = root.find('nx:sample', NS_MAP)
-        elements_el = s.find(f'{{{NS}}}elements')
+        NS_MAP = {"nx": NS}
+        s = root.find("nx:sample", NS_MAP)
+        elements_el = s.find(f"{{{NS}}}elements")
         self.assertIsNotNone(elements_el)
-        syms = [c.tag.split('}')[-1] for c in elements_el]
-        self.assertEqual(syms, ['Fe', 'Ni'])
+        syms = [c.tag.split("}")[-1] for c in elements_el]
+        self.assertEqual(syms, ["Fe", "Ni"])
 
     def test_empty_notes_omits_notes_element(self):
-        new_samples = [{'id': 's', 'name': 'S', 'description': '', 'notes': '', 'elements': []}]
+        new_samples = [
+            {"id": "s", "name": "S", "description": "", "notes": "", "elements": []}
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP = {'nx': NS}
-        s = root.find('nx:sample', NS_MAP)
-        self.assertIsNone(s.find(f'{{{NS}}}notes'))
+        NS_MAP = {"nx": NS}
+        s = root.find("nx:sample", NS_MAP)
+        self.assertIsNone(s.find(f"{{{NS}}}notes"))
 
     def test_samples_inserted_before_acquisition_activities(self):
-        new_samples = [{'id': 's', 'name': 'S', 'description': '', 'notes': '', 'elements': []}]
+        new_samples = [
+            {"id": "s", "name": "S", "description": "", "notes": "", "elements": []}
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
-        children_tags = [c.tag.split('}')[-1] for c in root]
-        sample_pos = children_tags.index('sample')
-        act_pos = children_tags.index('acquisitionActivity')
+        children_tags = [c.tag.split("}")[-1] for c in root]
+        sample_pos = children_tags.index("sample")
+        act_pos = children_tags.index("acquisitionActivity")
         self.assertLess(sample_pos, act_pos)
 
     def test_result_is_valid_xml(self):
@@ -447,48 +484,75 @@ class ApplySamplesTests(SimpleTestCase):
         ET.fromstring(result)
 
     def test_ref_attribute_written(self):
-        new_samples = [{'id': 's', 'ref': 'https://doi.org/10.1/x', 'name': 'S', 'description': '', 'notes': '', 'elements': []}]
+        new_samples = [
+            {
+                "id": "s",
+                "ref": "https://doi.org/10.1/x",
+                "name": "S",
+                "description": "",
+                "notes": "",
+                "elements": [],
+            }
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS_STR = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        s = root.find(f'{{{NS_STR}}}sample')
-        self.assertEqual(s.get('ref'), 'https://doi.org/10.1/x')
+        s = root.find(f"{{{NS_STR}}}sample")
+        self.assertEqual(s.get("ref"), "https://doi.org/10.1/x")
 
     def test_ref_attribute_omitted_when_empty(self):
-        new_samples = [{'id': 's', 'ref': '', 'name': 'S', 'description': '', 'notes': '', 'elements': []}]
+        new_samples = [
+            {
+                "id": "s",
+                "ref": "",
+                "name": "S",
+                "description": "",
+                "notes": "",
+                "elements": [],
+            }
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS_STR = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        s = root.find(f'{{{NS_STR}}}sample')
-        self.assertIsNone(s.get('ref'))
+        s = root.find(f"{{{NS_STR}}}sample")
+        self.assertIsNone(s.get("ref"))
 
     def test_invalid_element_symbols_are_filtered(self):
-        new_samples = [{'id': 's', 'name': 'S', 'description': '', 'notes': '', 'elements': ['Fe', 'NotAnElement', '1bad']}]
+        new_samples = [
+            {
+                "id": "s",
+                "name": "S",
+                "description": "",
+                "notes": "",
+                "elements": ["Fe", "NotAnElement", "1bad"],
+            }
+        ]
         result = _apply_samples(_NO_SAMPLES_XML, new_samples)
         root = ET.fromstring(result)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP = {'nx': NS}
-        s = root.find('nx:sample', NS_MAP)
-        elements_el = s.find(f'{{{NS}}}elements')
+        NS_MAP = {"nx": NS}
+        s = root.find("nx:sample", NS_MAP)
+        elements_el = s.find(f"{{{NS}}}elements")
         self.assertIsNotNone(elements_el)
-        syms = [c.tag.split('}')[-1] for c in elements_el]
-        self.assertEqual(syms, ['Fe'])  # only valid symbol retained
+        syms = [c.tag.split("}")[-1] for c in elements_el]
+        self.assertEqual(syms, ["Fe"])  # only valid symbol retained
 
 
 # ===========================================================================
 # _renumber_activities
 # ===========================================================================
 
+
 class RenumberActivitiesTests(SimpleTestCase):
     def _seqnos(self, xml_str):
         root = ET.fromstring(xml_str)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP = {'nx': NS}
-        return [a.get('seqno') for a in root.findall('nx:acquisitionActivity', NS_MAP)]
+        NS_MAP = {"nx": NS}
+        return [a.get("seqno") for a in root.findall("nx:acquisitionActivity", NS_MAP)]
 
     def test_already_consecutive_unchanged(self):
         result = _renumber_activities(_WITH_SAMPLES_XML)
-        self.assertEqual(self._seqnos(result), ['0', '1'])
+        self.assertEqual(self._seqnos(result), ["0", "1"])
 
     def test_gaps_are_filled(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
@@ -498,13 +562,13 @@ class RenumberActivitiesTests(SimpleTestCase):
           <acquisitionActivity seqno="5"/>
         </Experiment>"""
         result = _renumber_activities(xml)
-        self.assertEqual(self._seqnos(result), ['0', '1', '2'])
+        self.assertEqual(self._seqnos(result), ["0", "1", "2"])
 
     def test_single_activity_stays_zero(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
         xml = f'<Experiment xmlns="{NS}"><acquisitionActivity seqno="3"/></Experiment>'
         result = _renumber_activities(xml)
-        self.assertEqual(self._seqnos(result), ['0'])
+        self.assertEqual(self._seqnos(result), ["0"])
 
     def test_no_activities_returns_valid_xml(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
@@ -518,19 +582,23 @@ class RenumberActivitiesTests(SimpleTestCase):
 # _apply_activity_mutations
 # ===========================================================================
 
+
 class ApplyActivityMutationsTests(SimpleTestCase):
     NS_STR = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-    NS_MAP_LOC = {'nx': "https://data.nist.gov/od/dm/nexus/experiment/v1.0"}
+    NS_MAP_LOC = {"nx": "https://data.nist.gov/od/dm/nexus/experiment/v1.0"}
 
     def _seqnos(self, xml_str):
         root = ET.fromstring(xml_str)
-        return [a.get('seqno') for a in root.findall('nx:acquisitionActivity', self.NS_MAP_LOC)]
+        return [
+            a.get("seqno")
+            for a in root.findall("nx:acquisitionActivity", self.NS_MAP_LOC)
+        ]
 
     def _sample_id(self, xml_str, seqno):
         root = ET.fromstring(xml_str)
-        for a in root.findall('nx:acquisitionActivity', self.NS_MAP_LOC):
-            if a.get('seqno') == str(seqno):
-                el = a.find(f'{{{self.NS_STR}}}sampleID')
+        for a in root.findall("nx:acquisitionActivity", self.NS_MAP_LOC):
+            if a.get("seqno") == str(seqno):
+                el = a.find(f"{{{self.NS_STR}}}sampleID")
                 return el.text if el is not None else None
         return None
 
@@ -539,24 +607,36 @@ class ApplyActivityMutationsTests(SimpleTestCase):
     def test_delete_empty_activity(self):
         # seqno 1 is empty in _NO_SAMPLES_XML
         result, mapping = _apply_activity_mutations(
-            _NO_SAMPLES_XML, deleted_seqnos=['1'], new_activities=[], activity_sample_ids={}
+            _NO_SAMPLES_XML,
+            deleted_seqnos=["1"],
+            new_activities=[],
+            activity_sample_ids={},
         )
         root = ET.fromstring(result)
-        seqnos = [a.get('seqno') for a in root.findall('nx:acquisitionActivity', self.NS_MAP_LOC)]
-        self.assertNotIn('1', seqnos)
+        seqnos = [
+            a.get("seqno")
+            for a in root.findall("nx:acquisitionActivity", self.NS_MAP_LOC)
+        ]
+        self.assertNotIn("1", seqnos)
 
     def test_delete_non_empty_activity_raises_value_error(self):
         # seqno 0 in _NO_SAMPLES_XML has 1 dataset
         with self.assertRaises(ValueError):
             _apply_activity_mutations(
-                _NO_SAMPLES_XML, deleted_seqnos=['0'], new_activities=[], activity_sample_ids={}
+                _NO_SAMPLES_XML,
+                deleted_seqnos=["0"],
+                new_activities=[],
+                activity_sample_ids={},
             )
 
     def test_delete_nonexistent_seqno_silently_skipped(self):
         result, _ = _apply_activity_mutations(
-            _NO_SAMPLES_XML, deleted_seqnos=['99'], new_activities=[], activity_sample_ids={}
+            _NO_SAMPLES_XML,
+            deleted_seqnos=["99"],
+            new_activities=[],
+            activity_sample_ids={},
         )
-        self.assertEqual(self._seqnos(result), ['0', '1'])
+        self.assertEqual(self._seqnos(result), ["0", "1"])
 
     # --- insert ---
 
@@ -564,33 +644,33 @@ class ApplyActivityMutationsTests(SimpleTestCase):
         result, mapping = _apply_activity_mutations(
             _NO_SAMPLES_XML,
             deleted_seqnos=[],
-            new_activities=[{'temp_id': 'new-x', 'at_end': True}],
+            new_activities=[{"temp_id": "new-x", "at_end": True}],
             activity_sample_ids={},
         )
         root = ET.fromstring(result)
-        acts = root.findall('nx:acquisitionActivity', self.NS_MAP_LOC)
+        acts = root.findall("nx:acquisitionActivity", self.NS_MAP_LOC)
         self.assertEqual(len(acts), 3)
 
     def test_insert_after_seqno(self):
         result, mapping = _apply_activity_mutations(
             _NO_SAMPLES_XML,
             deleted_seqnos=[],
-            new_activities=[{'temp_id': 'new-x', 'after_seqno': '0'}],
+            new_activities=[{"temp_id": "new-x", "after_seqno": "0"}],
             activity_sample_ids={},
         )
         root = ET.fromstring(result)
-        acts = root.findall('nx:acquisitionActivity', self.NS_MAP_LOC)
+        acts = root.findall("nx:acquisitionActivity", self.NS_MAP_LOC)
         # should be seqno 0, new-x, 1 in that order
-        self.assertEqual(acts[0].get('seqno'), '0')
-        self.assertEqual(acts[1].get('seqno'), 'new-x')
-        self.assertEqual(acts[2].get('seqno'), '1')
+        self.assertEqual(acts[0].get("seqno"), "0")
+        self.assertEqual(acts[1].get("seqno"), "new-x")
+        self.assertEqual(acts[2].get("seqno"), "1")
 
     def test_insert_after_nonexistent_seqno_raises(self):
         with self.assertRaises(ValueError):
             _apply_activity_mutations(
                 _NO_SAMPLES_XML,
                 deleted_seqnos=[],
-                new_activities=[{'temp_id': 'new-x', 'after_seqno': '99'}],
+                new_activities=[{"temp_id": "new-x", "after_seqno": "99"}],
                 activity_sample_ids={},
             )
 
@@ -599,18 +679,21 @@ class ApplyActivityMutationsTests(SimpleTestCase):
     def test_mapping_original_seqno_to_final(self):
         # delete seqno 1, so seqno 0 stays at 0
         result, mapping = _apply_activity_mutations(
-            _NO_SAMPLES_XML, deleted_seqnos=['1'], new_activities=[], activity_sample_ids={}
+            _NO_SAMPLES_XML,
+            deleted_seqnos=["1"],
+            new_activities=[],
+            activity_sample_ids={},
         )
-        self.assertEqual(mapping['0'], '0')
+        self.assertEqual(mapping["0"], "0")
 
     def test_mapping_temp_id_to_final(self):
         result, mapping = _apply_activity_mutations(
             _NO_SAMPLES_XML,
             deleted_seqnos=[],
-            new_activities=[{'temp_id': 'new-x', 'at_end': True}],
+            new_activities=[{"temp_id": "new-x", "at_end": True}],
             activity_sample_ids={},
         )
-        self.assertIn('new-x', mapping)
+        self.assertIn("new-x", mapping)
 
     def test_mapping_shifts_after_deletion(self):
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
@@ -624,10 +707,10 @@ class ApplyActivityMutationsTests(SimpleTestCase):
           </acquisitionActivity>
         </Experiment>"""
         result, mapping = _apply_activity_mutations(
-            xml, deleted_seqnos=['1'], new_activities=[], activity_sample_ids={}
+            xml, deleted_seqnos=["1"], new_activities=[], activity_sample_ids={}
         )
         # old seqno 2 now maps to final seqno 1 (before renumber step)
-        self.assertEqual(mapping['2'], '1')
+        self.assertEqual(mapping["2"], "1")
 
     # --- sampleID ---
 
@@ -636,34 +719,34 @@ class ApplyActivityMutationsTests(SimpleTestCase):
             _NO_SAMPLES_XML,
             deleted_seqnos=[],
             new_activities=[],
-            activity_sample_ids={'0': 'steel-alloy-a'},
+            activity_sample_ids={"0": "steel-alloy-a"},
         )
-        self.assertEqual(self._sample_id(result, '0'), 'steel-alloy-a')
+        self.assertEqual(self._sample_id(result, "0"), "steel-alloy-a")
 
     def test_sample_id_cleared_when_null(self):
         result, _ = _apply_activity_mutations(
             _WITH_SAMPLES_XML,
             deleted_seqnos=[],
             new_activities=[],
-            activity_sample_ids={'0': None},
+            activity_sample_ids={"0": None},
         )
-        self.assertIsNone(self._sample_id(result, '0'))
+        self.assertIsNone(self._sample_id(result, "0"))
 
     def test_sample_id_inserted_after_start_time(self):
         result, _ = _apply_activity_mutations(
             _NO_SAMPLES_XML,
             deleted_seqnos=[],
             new_activities=[],
-            activity_sample_ids={'0': 'my-sample'},
+            activity_sample_ids={"0": "my-sample"},
         )
         root = ET.fromstring(result)
         NS = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        NS_MAP_L = {'nx': NS}
-        for act in root.findall('nx:acquisitionActivity', NS_MAP_L):
-            if act.get('seqno') == '0':
-                tags = [c.tag.split('}')[-1] for c in act]
-                start_pos = tags.index('startTime')
-                sid_pos = tags.index('sampleID')
+        NS_MAP_L = {"nx": NS}
+        for act in root.findall("nx:acquisitionActivity", NS_MAP_L):
+            if act.get("seqno") == "0":
+                tags = [c.tag.split("}")[-1] for c in act]
+                start_pos = tags.index("startTime")
+                sid_pos = tags.index("sampleID")
                 self.assertGreater(sid_pos, start_pos)
 
 
@@ -671,8 +754,11 @@ class ApplyActivityMutationsTests(SimpleTestCase):
 # _inject_setup_into_dataset
 # ===========================================================================
 
+
 class InjectSetupIntoDatasetTests(SimpleTestCase):
-    def _activity_and_dataset(self, xml=_TWO_ACTIVITY_XML, activity_index=0, dataset_index=0):
+    def _activity_and_dataset(
+        self, xml=_TWO_ACTIVITY_XML, activity_index=0, dataset_index=0
+    ):
         root = ET.fromstring(xml)
         activities = root.findall("nx:acquisitionActivity", NS_MAP)
         act = activities[activity_index]
@@ -684,8 +770,15 @@ class InjectSetupIntoDatasetTests(SimpleTestCase):
         _inject_setup_into_dataset(ds, act)
         names = _meta_names(ds)
         self.assertEqual(
-            {'Voltage', 'C2', 'Unique_to_1', 'StageX', 'Magnification', 'Creation Time'},
-            names
+            {
+                "Voltage",
+                "C2",
+                "Unique_to_1",
+                "StageX",
+                "Magnification",
+                "Creation Time",
+            },
+            names,
         )
 
     def test_setup_param_value_preserved(self):
@@ -734,6 +827,7 @@ class InjectSetupIntoDatasetTests(SimpleTestCase):
 # ===========================================================================
 # _recompute_activity_setup
 # ===========================================================================
+
 
 class RecomputeActivitySetupTests(SimpleTestCase):
     def _make_activity(self, *dataset_meta_dicts, existing_setup=None):
@@ -789,8 +883,7 @@ class RecomputeActivitySetupTests(SimpleTestCase):
         )
         _recompute_activity_setup(act)
         stagex_values = [
-            _find_meta(ds, "StageX").text
-            for ds in act.findall(_t("dataset"))
+            _find_meta(ds, "StageX").text for ds in act.findall(_t("dataset"))
         ]
         self.assertIn("-192", stagex_values)
         self.assertIn("-195", stagex_values)
@@ -846,29 +939,40 @@ class RecomputeActivitySetupTests(SimpleTestCase):
 # _apply_moves
 # ===========================================================================
 
+
 class ApplyMovesTests(SimpleTestCase):
     # original dataset counts in each activity
     orig_0 = _dataset_count_in_activity(_TWO_ACTIVITY_XML, "0")
     orig_1 = _dataset_count_in_activity(_TWO_ACTIVITY_XML, "1")
 
     def test_dataset_moved_to_target_activity(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         self.assertIn("image_001.dm3", _dataset_names_in_activity(result, "1"))
 
     def test_dataset_removed_from_source_activity(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         self.assertNotIn("image_001.dm3", _dataset_names_in_activity(result, "0"))
 
     def test_source_activity_loses_one_dataset(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         self.assertEqual(_dataset_count_in_activity(result, "0"), 1)
 
     def test_target_activity_gains_one_dataset(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         self.assertEqual(_dataset_count_in_activity(result, "1"), self.orig_1 + 1)
 
     def test_no_op_when_target_is_same_activity(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "0"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "0"}]
+        )
         self.assertEqual(_dataset_count_in_activity(result, "0"), self.orig_0)
         self.assertEqual(_dataset_count_in_activity(result, "1"), self.orig_1)
 
@@ -897,7 +1001,9 @@ class ApplyMovesTests(SimpleTestCase):
         self.assertEqual(_dataset_count_in_activity(result, "1"), self.orig_1 + 2)
 
     def test_out_of_range_index_ignored_gracefully(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 999, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 999, "targetActivitySeqno": "1"}]
+        )
         self.assertEqual(_dataset_count_in_activity(result, "0"), self.orig_0)
         self.assertEqual(_dataset_count_in_activity(result, "1"), self.orig_1)
 
@@ -908,7 +1014,9 @@ class ApplyMovesTests(SimpleTestCase):
         # Magnification=17677 differs from image_003 and image_004's 25000, so it gets demote
         # to meta. Only setup param in activity 1 should be Voltage, and image_003 and image_004
         # should gain Magnification meta elements
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         root = ET.fromstring(result)
         moved_ds = None
         act1 = None
@@ -919,10 +1027,14 @@ class ApplyMovesTests(SimpleTestCase):
                     name_el = ds.find("nx:name", NS_MAP)
                     if name_el is not None and name_el.text == "image_001.dm3":
                         moved_ds = ds
-        self.assertIsNotNone(moved_ds, "image_001.dm3 not found in activity 1 after move")
+        self.assertIsNotNone(
+            moved_ds, "image_001.dm3 not found in activity 1 after move"
+        )
         # Magnification differs between datasets so it must remain in meta for the moved dataset
         mag = _find_meta(moved_ds, "Magnification")
-        self.assertIsNotNone(mag, "Magnification not found in image_001.dm3 meta after move")
+        self.assertIsNotNone(
+            mag, "Magnification not found in image_001.dm3 meta after move"
+        )
         self.assertEqual(mag.text, "17677.0")
         # Voltage is common to all datasets in activity 1, so it must be in setup (not meta)
         self.assertIn("Voltage", _setup_param_names(act1))
@@ -932,7 +1044,9 @@ class ApplyMovesTests(SimpleTestCase):
         # image_001.dm3 comes from activity 0 (Magnification=17677.0);
         # after landing in activity 1 (setup Magnification=25000.0),
         # the injected value from source should be 17677.0, not 25000.0.
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         root = ET.fromstring(result)
         for act in root.findall("nx:acquisitionActivity", NS_MAP):
             if act.get("seqno") == "1":
@@ -947,10 +1061,12 @@ class ApplyMovesTests(SimpleTestCase):
 
     def test_target_setup_recomputed_to_reflect_common_values_only(self):
         # After moving image_001.dm3 (Voltage=300000, Magnification=17677) to activity 1
-        # which already has image_003.dm3 and image_004.dm3 (Voltage=300000, 
+        # which already has image_003.dm3 and image_004.dm3 (Voltage=300000,
         # Magnification=25000 after injection),
         # the common value is only Voltage. Magnification differs so must NOT be in setup.
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         root = ET.fromstring(result)
         for act in root.findall("nx:acquisitionActivity", NS_MAP):
             if act.get("seqno") == "1":
@@ -961,7 +1077,9 @@ class ApplyMovesTests(SimpleTestCase):
         self.fail("Activity 1 not found")
 
     def test_xml_result_is_valid_xml_string(self):
-        result = _apply_moves(_TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}])
+        result = _apply_moves(
+            _TWO_ACTIVITY_XML, [{"datasetIndex": 0, "targetActivitySeqno": "1"}]
+        )
         self.assertIsInstance(result, str)
         # Must be parseable
         ET.fromstring(result)
@@ -970,6 +1088,7 @@ class ApplyMovesTests(SimpleTestCase):
 # ===========================================================================
 # _apply_descriptions
 # ===========================================================================
+
 
 class ApplyDescriptionsTests(SimpleTestCase):
     def _get_description(self, xml_str, dataset_index):
@@ -1096,6 +1215,7 @@ class ApplyTitleTests(SimpleTestCase):
 # _dataset_creation_time
 # ===========================================================================
 
+
 class DatasetCreationTimeTests(SimpleTestCase):
     def _ds_with_meta(self, creation_time_value=None, name=None):
         ds = ET.Element(_t("dataset"))
@@ -1140,6 +1260,7 @@ class DatasetCreationTimeTests(SimpleTestCase):
 # _sort_datasets_by_creation_time
 # ===========================================================================
 
+
 class SortDatasetsByCreationTimeTests(SimpleTestCase):
     def _activity_with_datasets(self, *name_time_pairs):
         """Build activity with datasets given as (name, creation_time_iso) tuples."""
@@ -1156,10 +1277,7 @@ class SortDatasetsByCreationTimeTests(SimpleTestCase):
         return act
 
     def _names(self, activity_el):
-        return [
-            ds.find(_t("name")).text
-            for ds in activity_el.findall(_t("dataset"))
-        ]
+        return [ds.find(_t("name")).text for ds in activity_el.findall(_t("dataset"))]
 
     def test_sorts_ascending_by_creation_time(self):
         act = self._activity_with_datasets(
@@ -1199,6 +1317,7 @@ class SortDatasetsByCreationTimeTests(SimpleTestCase):
 # ===========================================================================
 # _apply_moves -- creation-time ordering
 # ===========================================================================
+
 
 class ApplyMovesOrderingTests(SimpleTestCase):
     def _names_in_activity(self, xml_str, seqno):
@@ -1372,9 +1491,7 @@ class ApplyMovesNoContaminationTests(SimpleTestCase):
                 # The TEM param must exist somewhere: either in the activity setup or
                 # in the dataset's own meta (depends on intersection result).
                 setup_names = _setup_param_names(act)
-                has_tem_mag = (
-                    "TEM_Mag" in setup_names or "TEM_Mag" in _meta_names(ds)
-                )
+                has_tem_mag = "TEM_Mag" in setup_names or "TEM_Mag" in _meta_names(ds)
                 self.assertTrue(
                     has_tem_mag,
                     f"{name_el.text} lost TEM_Mag after move",
@@ -1395,11 +1512,13 @@ class ApplyMovesNoContaminationTests(SimpleTestCase):
             ds = _get_dataset(result, name)
             self.assertIsNotNone(ds, f"{name} not found after batch move")
             self.assertNotIn(
-                "TEM_DataType", _meta_names(ds),
+                "TEM_DataType",
+                _meta_names(ds),
                 f"{name} was contaminated with TEM_DataType",
             )
             self.assertNotIn(
-                "TEM_Mag", _meta_names(ds),
+                "TEM_Mag",
+                _meta_names(ds),
                 f"{name} was contaminated with TEM_Mag",
             )
 
@@ -1407,6 +1526,7 @@ class ApplyMovesNoContaminationTests(SimpleTestCase):
 # ---------------------------------------------------------------------------
 # Sort fix: multiple datasets without timestamps must not raise TypeError
 # ---------------------------------------------------------------------------
+
 
 class SortNoTimestampTest(SimpleTestCase):
     """_sort_datasets_by_creation_time must not raise when multiple datasets lack timestamps."""
@@ -1426,10 +1546,10 @@ class SortNoTimestampTest(SimpleTestCase):
         activity = self._make_activity_xml(["a.dm3", "b.dm3", "c.dm3"])
         # Must not raise TypeError
         from nexuslims_annotate.views import _sort_datasets_by_creation_time
+
         _sort_datasets_by_creation_time(activity)
         names_after = [
-            ds.find(f"{{{NS}}}name").text
-            for ds in activity.findall(f"{{{NS}}}dataset")
+            ds.find(f"{{{NS}}}name").text for ds in activity.findall(f"{{{NS}}}dataset")
         ]
         # All names still present (order is stable for ties)
         self.assertEqual(set(names_after), {"a.dm3", "b.dm3", "c.dm3"})
@@ -1446,10 +1566,10 @@ class SortNoTimestampTest(SimpleTestCase):
         meta.text = "2024-01-15T10:00:00"
 
         from nexuslims_annotate.views import _sort_datasets_by_creation_time
+
         _sort_datasets_by_creation_time(activity)
         names_after = [
-            ds.find(f"{{{NS}}}name").text
-            for ds in activity.findall(f"{{{NS}}}dataset")
+            ds.find(f"{{{NS}}}name").text for ds in activity.findall(f"{{{NS}}}dataset")
         ]
         # Timestamped dataset sorts first
         self.assertEqual(names_after[0], "has_ts.dm3")
@@ -1490,6 +1610,7 @@ class AnnotateRecordViewTest(TestCase):
     @patch("nexuslims_annotate.views.data_api.get_by_id")
     def test_missing_record_returns_404(self, mock_get):
         from core_main_app.commons.exceptions import DoesNotExist
+
         mock_get.side_effect = DoesNotExist("not found")
         response = self.client.get("/annotate/bad-id/")
         self.assertEqual(response.status_code, 404)
@@ -1498,6 +1619,7 @@ class AnnotateRecordViewTest(TestCase):
     @patch("nexuslims_annotate.views.check_can_write")
     def test_unauthorized_returns_403(self, mock_check, mock_get):
         from core_main_app.access_control.exceptions import AccessControlError
+
         mock_get.return_value = _make_mock_data()
         mock_check.side_effect = AccessControlError("no access")
         response = self.client.get("/annotate/test-id/")
@@ -1555,6 +1677,7 @@ class AnnotateDescriptionsViewTest(TestCase):
     @patch("nexuslims_annotate.views.check_can_write")
     def test_authenticated_without_write_access_returns_403(self, mock_check, mock_get):
         from core_main_app.access_control.exceptions import AccessControlError
+
         mock_get.return_value = _make_mock_data()
         mock_check.side_effect = AccessControlError("no access")
         response = self.client.get("/annotate/test-id/descriptions/")
@@ -1617,6 +1740,7 @@ class AnnotateSaveOneViewTest(TestCase):
     def test_unauthorized_returns_403(self, mock_upsert, mock_get):
         """upsert raising AccessControlError returns 403."""
         from core_main_app.access_control.exceptions import AccessControlError
+
         mock_get.return_value = _make_mock_data()
         mock_upsert.side_effect = AccessControlError("no write access")
         response = self.client.post(
@@ -1643,6 +1767,7 @@ class AnnotatePanelViewTest(TestCase):
     @patch("nexuslims_annotate.views.data_api.get_by_id")
     def test_missing_record_returns_404(self, mock_get):
         from core_main_app.commons.exceptions import DoesNotExist
+
         mock_get.side_effect = DoesNotExist("not found")
         response = self.client.get("/annotate/bad-id/panel/")
         self.assertEqual(response.status_code, 404)
@@ -1675,6 +1800,7 @@ class AnnotateSaveViewTest(TestCase):
     @patch("nexuslims_annotate.views.data_api.get_by_id")
     def test_missing_record_returns_404_for_ajax(self, mock_get):
         from core_main_app.commons.exceptions import DoesNotExist
+
         mock_get.side_effect = DoesNotExist("not found")
         response = self.client.post(
             "/annotate/bad-id/save/",
@@ -1703,149 +1829,165 @@ class AnnotateSaveStructuralTests(TestCase):
     """Tests for structural mutations via annotate_save."""
 
     def setUp(self):
-        self.user = User.objects.create_user(username='testuser_struct', password='pass')
+        self.user = User.objects.create_user(
+            username="testuser_struct", password="pass"
+        )
         self.client.force_login(self.user)
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_delete_non_empty_activity_returns_400(self, mock_upsert, mock_get):
         mock_get.return_value = _make_mock_data(_NO_SAMPLES_XML)
         response = self.client.post(
-            '/annotate/test-id/save/',
+            "/annotate/test-id/save/",
             {
-                'deleted_seqnos': json.dumps(['0']),  # seqno 0 has 1 dataset
-                'new_activities': '[]',
-                'activity_sample_ids': '{}',
-                'samples': '[]',
-                'moves': '[]',
+                "deleted_seqnos": json.dumps(["0"]),  # seqno 0 has 1 dataset
+                "new_activities": "[]",
+                "activity_sample_ids": "{}",
+                "samples": "[]",
+                "moves": "[]",
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 400)
         body = json.loads(response.content)
-        self.assertIn('error', body)
+        self.assertIn("error", body)
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_delete_empty_activity_succeeds(self, mock_upsert, mock_get):
         data_obj = _make_mock_data(_NO_SAMPLES_XML)
         mock_get.return_value = data_obj
         response = self.client.post(
-            '/annotate/test-id/save/',
+            "/annotate/test-id/save/",
             {
-                'deleted_seqnos': json.dumps(['1']),  # seqno 1 is empty
-                'new_activities': '[]',
-                'activity_sample_ids': '{}',
-                'samples': '[]',
-                'moves': '[]',
+                "deleted_seqnos": json.dumps(["1"]),  # seqno 1 is empty
+                "new_activities": "[]",
+                "activity_sample_ids": "{}",
+                "samples": "[]",
+                "moves": "[]",
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(json.loads(response.content).get('success'))
+        self.assertTrue(json.loads(response.content).get("success"))
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_malformed_json_returns_400(self, mock_upsert, mock_get):
         mock_get.return_value = _make_mock_data()
         response = self.client.post(
-            '/annotate/test-id/save/',
+            "/annotate/test-id/save/",
             {
-                'deleted_seqnos': 'not json',
-                'new_activities': '[]',
-                'activity_sample_ids': '{}',
-                'samples': '[]',
-                'moves': '[]',
+                "deleted_seqnos": "not json",
+                "new_activities": "[]",
+                "activity_sample_ids": "{}",
+                "samples": "[]",
+                "moves": "[]",
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 400)
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_samples_saved_in_xml(self, mock_upsert, mock_get):
         data_obj = _make_mock_data(_NO_SAMPLES_XML)
         mock_get.return_value = data_obj
-        samples = [{'id': 'test-s', 'name': 'Test Sample', 'description': 'desc', 'notes': '', 'elements': ['Fe']}]
-        response = self.client.post(
-            '/annotate/test-id/save/',
+        samples = [
             {
-                'deleted_seqnos': '[]',
-                'new_activities': '[]',
-                'activity_sample_ids': '{}',
-                'samples': json.dumps(samples),
-                'moves': '[]',
+                "id": "test-s",
+                "name": "Test Sample",
+                "description": "desc",
+                "notes": "",
+                "elements": ["Fe"],
+            }
+        ]
+        response = self.client.post(
+            "/annotate/test-id/save/",
+            {
+                "deleted_seqnos": "[]",
+                "new_activities": "[]",
+                "activity_sample_ids": "{}",
+                "samples": json.dumps(samples),
+                "moves": "[]",
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
         saved_xml = mock_upsert.call_args[0][0].content
         root = ET.fromstring(saved_xml)
-        s = root.find(f'{{{NS}}}sample')
+        s = root.find(f"{{{NS}}}sample")
         self.assertIsNotNone(s)
-        self.assertEqual(s.get('id'), 'test-s')
+        self.assertEqual(s.get("id"), "test-s")
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_existing_save_still_works_without_new_fields(self, mock_upsert, mock_get):
         """Existing callers that omit the new fields should not break."""
         mock_get.return_value = _make_mock_data()
         response = self.client.post(
-            '/annotate/test-id/save/',
-            {'dataset_0_description': 'A description'},
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            "/annotate/test-id/save/",
+            {"dataset_0_description": "A description"},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(json.loads(response.content).get('success'))
+        self.assertTrue(json.loads(response.content).get("success"))
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_move_to_new_activity_is_translated(self, mock_upsert, mock_get):
         """A move targeting a temp_id is correctly translated to the final seqno."""
         data_obj = _make_mock_data(_NO_SAMPLES_XML)
         mock_get.return_value = data_obj
         response = self.client.post(
-            '/annotate/test-id/save/',
+            "/annotate/test-id/save/",
             {
-                'deleted_seqnos': '[]',
-                'new_activities': json.dumps([{'temp_id': 'new-x', 'at_end': True}]),
-                'activity_sample_ids': '{}',
-                'samples': '[]',
-                'moves': json.dumps([{'datasetIndex': 0, 'targetActivitySeqno': 'new-x'}]),
+                "deleted_seqnos": "[]",
+                "new_activities": json.dumps([{"temp_id": "new-x", "at_end": True}]),
+                "activity_sample_ids": "{}",
+                "samples": "[]",
+                "moves": json.dumps(
+                    [{"datasetIndex": 0, "targetActivitySeqno": "new-x"}]
+                ),
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
         saved_xml = mock_upsert.call_args[0][0].content
         root = ET.fromstring(saved_xml)
-        acts = root.findall(f'{{{NS}}}acquisitionActivity')
+        acts = root.findall(f"{{{NS}}}acquisitionActivity")
         # 3 activities total (0, 1, new-x now renumbered to 2)
         self.assertEqual(len(acts), 3)
         # dataset 0 (only.dm3) moved to the last activity
         last_act = acts[-1]
-        ds_names = [ds.find(f'{{{NS}}}name').text for ds in last_act.findall(f'{{{NS}}}dataset')]
-        self.assertIn('only.dm3', ds_names)
+        ds_names = [
+            ds.find(f"{{{NS}}}name").text for ds in last_act.findall(f"{{{NS}}}dataset")
+        ]
+        self.assertIn("only.dm3", ds_names)
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
-    def test_missing_samples_field_preserves_existing_samples(self, mock_upsert, mock_get):
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
+    def test_missing_samples_field_preserves_existing_samples(
+        self, mock_upsert, mock_get
+    ):
         """If 'samples' is absent from POST, existing samples must not be removed."""
         data_obj = _make_mock_data(_WITH_SAMPLES_XML)
         mock_get.return_value = data_obj
         response = self.client.post(
-            '/annotate/test-id/save/',
-            {'dataset_0_description': 'A description'},  # no 'samples' field
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            "/annotate/test-id/save/",
+            {"dataset_0_description": "A description"},  # no 'samples' field
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
         saved_xml = mock_upsert.call_args[0][0].content
         root = ET.fromstring(saved_xml)
         NS_STR = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
-        samples = root.findall(f'{{{NS_STR}}}sample')
+        samples = root.findall(f"{{{NS_STR}}}sample")
         self.assertEqual(len(samples), 2)  # _WITH_SAMPLES_XML has 2 samples
 
-    @patch('nexuslims_annotate.views.data_api.get_by_id')
-    @patch('nexuslims_annotate.views.data_api.upsert')
+    @patch("nexuslims_annotate.views.data_api.get_by_id")
+    @patch("nexuslims_annotate.views.data_api.upsert")
     def test_move_after_deletion_uses_original_seqno(self, mock_upsert, mock_get):
         """Moving a dataset to an activity whose seqno did not change still works after a deletion."""
         NS_STR = "https://data.nist.gov/od/dm/nexus/experiment/v1.0"
@@ -1867,26 +2009,29 @@ class AnnotateSaveStructuralTests(TestCase):
         mock_get.return_value = data_obj
         # Delete seqno 1, move dataset from seqno 0 to seqno 2
         response = self.client.post(
-            '/annotate/test-id/save/',
+            "/annotate/test-id/save/",
             {
-                'deleted_seqnos': json.dumps(['1']),
-                'new_activities': '[]',
-                'activity_sample_ids': '{}',
-                'samples': '[]',
-                'moves': json.dumps([{'datasetIndex': 0, 'targetActivitySeqno': '2'}]),
+                "deleted_seqnos": json.dumps(["1"]),
+                "new_activities": "[]",
+                "activity_sample_ids": "{}",
+                "samples": "[]",
+                "moves": json.dumps([{"datasetIndex": 0, "targetActivitySeqno": "2"}]),
             },
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 200)
         saved_xml = mock_upsert.call_args[0][0].content
         root = ET.fromstring(saved_xml)
-        acts = root.findall(f'{{{NS_STR}}}acquisitionActivity')
+        acts = root.findall(f"{{{NS_STR}}}acquisitionActivity")
         # After deletion + renumber, 2 activities remain
         self.assertEqual(len(acts), 2)
         # The last activity should now have 'only.dm3'
         last_act = acts[-1]
-        ds_names = [ds.find(f'{{{NS_STR}}}name').text for ds in last_act.findall(f'{{{NS_STR}}}dataset')]
-        self.assertIn('only.dm3', ds_names)
+        ds_names = [
+            ds.find(f"{{{NS_STR}}}name").text
+            for ds in last_act.findall(f"{{{NS_STR}}}dataset")
+        ]
+        self.assertIn("only.dm3", ds_names)
 
     @patch('nexuslims_annotate.views.data_api.get_by_id')
     @patch('nexuslims_annotate.views.data_api.upsert')
@@ -1943,6 +2088,7 @@ class AnnotateSaveOneDoesNotExistTest(TestCase):
     @patch("nexuslims_annotate.views.data_api.get_by_id")
     def test_missing_record_returns_404(self, mock_get):
         from core_main_app.commons.exceptions import DoesNotExist
+
         mock_get.side_effect = DoesNotExist("not found")
         response = self.client.post(
             "/annotate/bad-id/save-one/",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,4 @@
-""" Settings file to run the tests.
-"""
+"""Settings file to run the tests."""
 
 from dotenv import load_dotenv  # noqa
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,5 +1,5 @@
-""" Url router
-"""
+"""Url router"""
+
 from django.http import HttpResponse
 from django.urls import include, path
 
@@ -9,7 +9,7 @@ def _stub_view(request):
 
 
 urlpatterns = [
-    path('annotate/', include('nexuslims_annotate.urls')),
+    path("annotate/", include("nexuslims_annotate.urls")),
     # Stub for core_main_app URL referenced by the annotate template
-    path('data/', _stub_view, name='core_main_app_data_detail'),
+    path("data/", _stub_view, name="core_main_app_data_detail"),
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -62,11 +62,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -116,71 +116,71 @@ wheels = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/1d/4fdabeef4e231153b6ed7567602f3b68265ec4e5b76d6024cf647d43d981/charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f", size = 294823, upload-time = "2026-03-15T18:51:15.755Z" },
-    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843", size = 198527, upload-time = "2026-03-15T18:51:17.177Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf", size = 218388, upload-time = "2026-03-15T18:51:18.934Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8", size = 214563, upload-time = "2026-03-15T18:51:20.374Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9", size = 206587, upload-time = "2026-03-15T18:51:21.807Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88", size = 194724, upload-time = "2026-03-15T18:51:23.508Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84", size = 202956, upload-time = "2026-03-15T18:51:25.239Z" },
-    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd", size = 201923, upload-time = "2026-03-15T18:51:26.682Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c", size = 195366, upload-time = "2026-03-15T18:51:28.129Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194", size = 219752, upload-time = "2026-03-15T18:51:29.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc", size = 203296, upload-time = "2026-03-15T18:51:30.921Z" },
-    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f", size = 215956, upload-time = "2026-03-15T18:51:32.399Z" },
-    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2", size = 208652, upload-time = "2026-03-15T18:51:34.214Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/11/897052ea6af56df3eef3ca94edafee410ca699ca0c7b87960ad19932c55e/charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d", size = 143940, upload-time = "2026-03-15T18:51:36.15Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/5c/724b6b363603e419829f561c854b87ed7c7e31231a7908708ac086cdf3e2/charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389", size = 154101, upload-time = "2026-03-15T18:51:37.876Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a5/7abf15b4c0968e47020f9ca0935fb3274deb87cb288cd187cad92e8cdffd/charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f", size = 143109, upload-time = "2026-03-15T18:51:39.565Z" },
-    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
-    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
-    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
-    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
-    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
-    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
-    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
-    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
-    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
-    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
-    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
-    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
-    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -231,87 +231,87 @@ wheels = [
 
 [[package]]
 name = "core-composer-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/85/334d0f4868c32ffaf79d76aef627cee2cbb6d6700cbf37ae71101d7fce2f/core_composer_app-2.20.0.tar.gz", hash = "sha256:0b928a779742255e1b1d9ebe99db61d2f4488d4191373853c1377a883e923243", size = 61565, upload-time = "2026-03-05T19:37:41.063Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/a1/fee42fa3badac95c7a61f8ec1102e57866cceff12cb80143b2708ab6b2db/core_composer_app-2.21.0.tar.gz", hash = "sha256:45fcdbdf2ceb916e86312405ba1fc4c32d109ebca17a2f8136cd2368a09a7ba6", size = 61545, upload-time = "2026-04-21T19:38:44.563Z" }
 
 [[package]]
 name = "core-curate-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
     { name = "core-parser-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/e9/a6a9ddd056e14c68d052195a0e0c2f9b954cdf52832da3c13e792adbc281/core_curate_app-2.20.0.tar.gz", hash = "sha256:83e6f6c6027efd15c593757c1caa51fd39639f7f3f1a7ad7259b005ea3e40b7d", size = 61611, upload-time = "2026-03-05T19:38:03.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ca/59b07bcb0c00945b06a688d8fd2370605bdf7788f6c83d6910a95515f2a3/core_curate_app-2.21.0.tar.gz", hash = "sha256:03245e2c6e1afbf7c3d34fff069a122bba1bcc0c837f0bee334d86e132b31d9f", size = 61654, upload-time = "2026-04-21T19:39:23.946Z" }
 
 [[package]]
 name = "core-dashboard-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-dashboard-common-app" },
     { name = "core-explore-common-app" },
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/4a/f81ddd1e5110739298057574b97c8b6bb0392a7165ee039c1f3d2630dceb/core_dashboard_app-2.20.0.tar.gz", hash = "sha256:c367667b57493511e0e604adcab6266b887e43ed19ecc2d82208a971997c9b23", size = 18644, upload-time = "2026-03-05T19:38:36.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/86/80ae84a185b7974309de596afdb5c64abdebd1c72112bc8e5162b5994646/core_dashboard_app-2.21.0.tar.gz", hash = "sha256:64bd341156e4aee9f468e67ea1307606db4c8e120b59e5c9068bfa3a15c2621f", size = 18612, upload-time = "2026-04-21T19:39:45.347Z" }
 
 [[package]]
 name = "core-dashboard-common-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/53/0f0090d06b4789a9e0cb6d1a478a3d13134de76403be0dbd91826a75abb0/core_dashboard_common_app-2.20.0.tar.gz", hash = "sha256:2c1cf1f3b62ac0f634345296149d959df1a35adf6f9ae218345a534dd79d89ba", size = 43286, upload-time = "2026-03-05T19:38:48.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/d4/8c287a4dead0c47e25c4347e45c1ba30f73a8c01f5f8048ad18047a408c6/core_dashboard_common_app-2.21.0.tar.gz", hash = "sha256:1a547041d7ac95201c096875c3763fb32cada30feaf27ca0e94840f25f023d90", size = 43954, upload-time = "2026-04-21T19:40:02.184Z" }
 
 [[package]]
 name = "core-explore-common-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/21/006cfcb07ee91734157925fce259fa15ec9dc81779114dc08141c5f9500f/core_explore_common_app-2.20.0.tar.gz", hash = "sha256:436fbfe63c15a06e6c0a84c7fed5a816c03caaf37f167371ca1c356c21e7d00e", size = 46035, upload-time = "2026-03-05T19:39:13.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/af/287f40628e1a58c8126b8c76aa4ea5332003678c2168f65ad968ad09f012/core_explore_common_app-2.21.0.tar.gz", hash = "sha256:685b4cf063a2bba8ff32b9c1bfd24181218ad70108f75c93db7aa1c1183ac871", size = 46047, upload-time = "2026-04-21T19:40:34.443Z" }
 
 [[package]]
 name = "core-explore-example-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-explore-common-app" },
     { name = "core-main-app" },
     { name = "core-parser-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/de/723b46a8dff5b9f553813d1a98b7c8dfacd93366c9de501ca9757c539653/core_explore_example_app-2.20.0.tar.gz", hash = "sha256:443251857c1da9ccb22dbf0a6bb8b0dea27623cc9bdb57dbec1c3e9c7428abc4", size = 54712, upload-time = "2026-03-05T19:39:29.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/a8/f14dcc6ff00a6b76dfafe84e9110222b0d0ef62eebe9de7c7dae65de2bc2/core_explore_example_app-2.21.0.tar.gz", hash = "sha256:1d4002896356a1537285111ff1bc2f955d688d00ec41d2c846df123ffa003124", size = 54749, upload-time = "2026-04-21T19:40:51.793Z" }
 
 [[package]]
 name = "core-explore-federated-search-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-explore-common-app" },
     { name = "core-federated-search-app" },
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/3d/17c7b25234a5faaf51d3ab99f69718797149a11201174566a1c324fd0813/core_explore_federated_search_app-2.20.0.tar.gz", hash = "sha256:df2ebcdb83069bb7dd1d272806c50d33c2c660684ad9e724e061cd0df32dceb7", size = 21223, upload-time = "2026-03-05T19:39:44.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/96/fd53f28c5fddba355d6cb08bf7d3b24bf3437549aa1da80e871166357d71/core_explore_federated_search_app-2.21.0.tar.gz", hash = "sha256:f35178c0fd39b4fc1a1ae3aade500254ac9fc0e07b3daf082047e849b1e2986e", size = 21246, upload-time = "2026-04-21T19:41:07.413Z" }
 
 [[package]]
 name = "core-explore-keyword-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-explore-common-app" },
     { name = "core-main-app" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/d9/5317ec95f3ea6c040f918669e5cfd6704968250264b0b1c995fbe25372ef/core_explore_keyword_app-2.20.0.tar.gz", hash = "sha256:1c1aca27f6a50a267aa65e2ebbe9f346b47e764eefc555a19632b69ccd4b807d", size = 54293, upload-time = "2026-03-05T19:39:58.263Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/db/24a2cb1dc982933ea851c41decb734648e99a69f4bc9ed6f513098955e77/core_explore_keyword_app-2.21.0.tar.gz", hash = "sha256:3d4cccd7266ff2990caeb691518cdca05d5a3a3e8528d9fdf850cce692e51b25", size = 54247, upload-time = "2026-04-21T19:41:23.309Z" }
 
 [[package]]
 name = "core-exporters-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -322,11 +322,11 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/02/85ae2c8bb120cc1029855b181c47a21aab23ccbc088916aece9a1d4f1471/core_exporters_app-2.20.0.tar.gz", hash = "sha256:ec81af34a54b86e5408ed59535bb3e5cca3d00532f76137e712a2d3f69bfcda6", size = 51713, upload-time = "2026-03-05T19:40:52.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/df/a7b3de01b2140259465c5e150f187c7aa7ae79875cef9c4d63efb860f275/core_exporters_app-2.21.0.tar.gz", hash = "sha256:6638998d10aa40cb25d3fb2d8aa6edfa5892d85d9ab9446a379a36047071980e", size = 51684, upload-time = "2026-04-21T19:42:20.67Z" }
 
 [[package]]
 name = "core-federated-search-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-explore-common-app" },
@@ -337,11 +337,11 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/cf/9a1ee25dfd4c3ddc4f28c96d9b0481377012d71742369cce25bde3f76010/core_federated_search_app-2.20.0.tar.gz", hash = "sha256:5786caacdf6227c92770bd183d65095a378cb39de56f9e89bb19a4db564808c4", size = 31721, upload-time = "2026-03-05T19:41:04.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/4f/ef7e8b2e393fdf9f1293b34022c70b83c4441032506985150631193c7ddf/core_federated_search_app-2.21.0.tar.gz", hash = "sha256:7362124e517a192dcfff516c5e54934d2381ecae2471767792624ebc3fce778e", size = 31762, upload-time = "2026-04-21T19:42:39.035Z" }
 
 [[package]]
 name = "core-file-preview-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
@@ -349,11 +349,11 @@ dependencies = [
     { name = "django-simple-menu" },
     { name = "djangorestframework" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/7a/eca1c2529556d5412e8750946d943c09d720eee43e6a9d0c046b534fd743/core_file_preview_app-2.20.0.tar.gz", hash = "sha256:7abc5a35b231a56857c723d937096d46ea7d0e698a5728c251146638d1d2d954", size = 7601, upload-time = "2026-03-05T19:41:13.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/7a/429073440f0541c4e4ea4f77c87f90606b16af6de38372f0058c62f23f4c/core_file_preview_app-2.21.0.tar.gz", hash = "sha256:763167380396a6ea9e367cf88581154978fbbd3a0c3f037ba8628742b4392dc6", size = 7617, upload-time = "2026-04-21T19:42:47.725Z" }
 
 [[package]]
 name = "core-linked-records-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-explore-common-app" },
@@ -363,11 +363,11 @@ dependencies = [
     { name = "djangorestframework-xml" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/11/9b04b2ba4fb400ac4e2e3e61056f00376193158d9d990c66e93e69ce3c19/core_linked_records_app-2.20.0.tar.gz", hash = "sha256:31192b0608a57cdb1844183018eeb951c0cde66f8a15a23704d26bec3d4b035a", size = 89704, upload-time = "2026-03-05T19:41:36.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/57/6c0c4e717b749b41554b33c1a9d3809c56cb77b2a2bd17d1be22d26e59ea/core_linked_records_app-2.21.0.tar.gz", hash = "sha256:c7580bb07866bf27af0b126b596902eda3ca21645202f159daa2024fe74ab968", size = 89673, upload-time = "2026-04-21T19:43:16.281Z" }
 
 [[package]]
 name = "core-main-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -388,7 +388,7 @@ dependencies = [
     { name = "xml-utils" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/16/e32bbcf1b0eade752acb6949b05c3f96cbd3d5d17e95fcfd436687023028/core_main_app-2.20.0.tar.gz", hash = "sha256:7ec7dd6e79affeceabc0163c96b29c7cfb9e1495f8442612b575774e21a8f67f", size = 617705, upload-time = "2026-03-05T19:42:46.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/e2/0a30c1fe58581fa9758516c8d4961e7b17b2a922691a13fe24d34bad7b42/core_main_app-2.21.0.tar.gz", hash = "sha256:0605ef4f2db91bdda6d3925ec418abc34ff5581ac193783649de5b404ff78b40", size = 619884, upload-time = "2026-04-21T19:44:39.339Z" }
 
 [package.optional-dependencies]
 auth = [
@@ -398,7 +398,7 @@ auth = [
 
 [[package]]
 name = "core-module-advanced-blob-host-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
@@ -407,61 +407,61 @@ dependencies = [
     { name = "core-parser-app" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c3/19439b522c3b1ff27a86d00f05b4835cf400d256802b9301567e02382d0b/core_module_advanced_blob_host_app-2.20.0.tar.gz", hash = "sha256:6c23a7d657e2eea4abffc77cd5364736e802effd6ef73bff8ad009136e88cd1e", size = 5803, upload-time = "2026-03-05T19:43:13.285Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/73/dc5cad515ceef539aba316fcc42cbe82e96e5db97b50da9534843fc0171f/core_module_advanced_blob_host_app-2.21.0.tar.gz", hash = "sha256:6e9f331ec565ae2d06b8d0a8d038a7c60c8db0e1dde265f1b1c9850946990254", size = 5834, upload-time = "2026-04-21T19:45:10.839Z" }
 
 [[package]]
 name = "core-module-blob-host-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
     { name = "core-parser-app" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/04/492e581b336682f145742e2200e862e0664a46055c5bc5d3062014325724/core_module_blob_host_app-2.20.0.tar.gz", hash = "sha256:fcdf97bd515b28d0e80e9665770813153f15a430856d3c42c6c24be2a80e3355", size = 8193, upload-time = "2026-03-05T19:43:21.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b3/23087d338bd0ee11a7355ecf2d7e4a401a2429f14ee13764c60ddcebd7bf/core_module_blob_host_app-2.21.0.tar.gz", hash = "sha256:60920757d339912e743301ca2937cb5fe96fd83c31dbc6646490574c4ba52f4a", size = 8189, upload-time = "2026-04-21T19:45:19.442Z" }
 
 [[package]]
 name = "core-module-chemical-composition-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/b5/60e66e5bc7699f61c9da048199994c4e6bbd3e86b16da8319105a14ce6a0/core_module_chemical_composition_app-2.20.0.tar.gz", hash = "sha256:f4eccae496112fd8b636173c0db2f4d7c8e80e0653c8f8edad0cf4fc7cb5a96f", size = 7473, upload-time = "2026-03-05T19:43:29.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/af/de38509b88255e4f711e3667303955a63e00603599a6e8eda9dc06ab2aa1/core_module_chemical_composition_app-2.21.0.tar.gz", hash = "sha256:a178849e7bef951099c353e603828225ac45e3e9f9b290ba9546f09d8c4a57e9", size = 7474, upload-time = "2026-04-21T19:45:31.146Z" }
 
 [[package]]
 name = "core-module-chemical-composition-simple-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/6c/ba89903882173b74b31b3468b1ca2438620222660c356dae2c6c6c9f1707/core_module_chemical_composition_simple_app-2.20.0.tar.gz", hash = "sha256:ef7ff98ca1a63889535ad16bd59c9c6afde984671f26b19555268ecd07b2b98c", size = 4584, upload-time = "2026-03-05T19:43:37.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/06/8e0f7e7008a36b2c57023fd221546a90554069f4a83eb07f799f9229f6fb/core_module_chemical_composition_simple_app-2.21.0.tar.gz", hash = "sha256:009d889359a13bf27d666ed0fecc420751cd2ee5ad063cad8fa936bac6847f1a", size = 4598, upload-time = "2026-04-21T19:45:39.78Z" }
 
 [[package]]
 name = "core-module-excel-uploader-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-parser-app" },
     { name = "django" },
     { name = "xlrd" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/02/76004d7e8af992a4595c0ac93576f7e69a0c659f48c8ed91c51d22c040be/core_module_excel_uploader_app-2.20.0.tar.gz", hash = "sha256:0852364ebbc6ca9ab392f80d823630509f216c8ec480537d073738b0f28e7920", size = 14169, upload-time = "2026-03-05T19:43:45.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/4a/c12f7fe095d741eee77ce748672a9c168b7d80c0e81b270452d896f473fd/core_module_excel_uploader_app-2.21.0.tar.gz", hash = "sha256:1e1384b0b98141ec2f9e201d9ca5b0b03b43c31829c9b0872982ec7b39f69d11", size = 14169, upload-time = "2026-04-21T19:45:48.498Z" }
 
 [[package]]
 name = "core-module-periodic-table-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-parser-app" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/c4/6783d68f852eaee3a5e303263a94e89a0d6af0e348800d426c29f1195cc0/core_module_periodic_table_app-2.20.0.tar.gz", hash = "sha256:f909961e9074eeceef539f9393b99a4a16e0afdb18a7ce6dbfa13e17fbc87680", size = 7162, upload-time = "2026-03-05T19:44:08.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/0c/1ecb9e0ca9bbc04d2af5fcb70170ad79716bd9ca649e1ec58ba41ce8afa6/core_module_periodic_table_app-2.21.0.tar.gz", hash = "sha256:c7b63c5fc6d1c80121c4d96afd3a51c6c1e5fac500e579d50e747b5f26f3640b", size = 7137, upload-time = "2026-04-21T19:46:17.39Z" }
 
 [[package]]
 name = "core-module-remote-blob-host-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
@@ -469,21 +469,21 @@ dependencies = [
     { name = "core-parser-app" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/08/780917309f3c875fe5c6c049d903d9e3e74ed29fd6aaa48a4db05fa20a3b/core_module_remote_blob_host_app-2.20.0.tar.gz", hash = "sha256:db291fee0c2605183eaf67e47ebf06b3269edf50eb9791a3b3f899e54b8770f4", size = 4230, upload-time = "2026-03-05T19:44:23.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/1e/e899c095ea373e90cb242417ffa633993e9d9f40363b9064795aab56c866/core_module_remote_blob_host_app-2.21.0.tar.gz", hash = "sha256:5929ad188601606e185ff20be7157ada3357e57ba08e4258e8e14b5fa7fc27df", size = 4223, upload-time = "2026-04-21T19:46:33.862Z" }
 
 [[package]]
 name = "core-module-text-area-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-parser-app" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/cb/bae6e2f1ce73ea9922c22e13bf56b0fd781d450b945476ab5c7b782a3353/core_module_text_area_app-2.20.0.tar.gz", hash = "sha256:5a5fe2bf2d57cebea5b3a2860a09d84f907a0f6c236429452e95b19965f76ad3", size = 5301, upload-time = "2026-03-05T19:44:38.547Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/b5/524553ee6ea0da4916778588a5d34f6503415009de7d8999df0852d4cb75/core_module_text_area_app-2.21.0.tar.gz", hash = "sha256:e23005cba05975149e7077b771211f6727972f0343b0a625b45a5a8de562a97c", size = 5306, upload-time = "2026-04-21T19:46:52.274Z" }
 
 [[package]]
 name = "core-parser-app"
-version = "2.20.0"
+version = "2.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery" },
@@ -492,11 +492,11 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "lxml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/8c/d1596039b09c47bdfdb5a7b8c891cd7e82833d0dd23aabdc3b443327be6d/core_parser_app-2.20.0.tar.gz", hash = "sha256:3710a75b790e1fee19f1a81a8ba2c3dcf712a00d83f4772f8026ef7688bbfa8c", size = 81088, upload-time = "2026-03-05T19:45:47.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/57/1dfe8a97d028cbe27d4e78938dddb354e538b9ebbdeee332f9389931b234/core_parser_app-2.21.1.tar.gz", hash = "sha256:29dc9c405722ec0674eca751b9e6ee376698508203995d37ceb737dd2ef553f4", size = 81066, upload-time = "2026-04-22T15:54:47.55Z" }
 
 [[package]]
 name = "core-website-app"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "core-main-app" },
@@ -506,18 +506,18 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "markdown" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/79/4018ae4e05589bedd4bf4794e6e0799e14ea95170f7dcf2a4b0b77b611f9/core_website_app-2.20.0.tar.gz", hash = "sha256:1732205a7a5709b0b702d65e5aca8c2a5664b2e5467d41151102a16cea21e1e5", size = 34834, upload-time = "2026-03-05T19:46:32.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/f0/97ac4bc63aa3abbf870b9d7f229f6eb2d0f8458fbce8ad762d03508ca81b/core_website_app-2.21.0.tar.gz", hash = "sha256:993cd80303c9f12d5fe41e568cad7918b7ff5b4ffd8bbbfcd84ed7e3bf85b2b1", size = 34831, upload-time = "2026-04-21T19:49:05.517Z" }
 
 [[package]]
 name = "cron-descriptor"
-version = "2.0.6"
+version = "2.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/31/0b21d1599656b2ffa6043e51ca01041cd1c0f6dacf5a3e2b620ed120e7d8/cron_descriptor-2.0.6.tar.gz", hash = "sha256:e39d2848e1d8913cfb6e3452e701b5eec662ee18bea8cc5aa53ee1a7bb217157", size = 49456, upload-time = "2025-09-03T16:30:22.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/ce/cd3cc454ea73e8a38be79723b925611d2556037f938372ad594373f187b4/cron_descriptor-2.0.8.tar.gz", hash = "sha256:7e487efe14a99a3c1c23bb5302bb75c8bf5d54bca82931bf71f5ae2855939772", size = 49971, upload-time = "2026-03-23T13:19:17.963Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/cc/361326a54ad92e2e12845ad15e335a4e14b8953665007fb514d3393dfb0f/cron_descriptor-2.0.6-py3-none-any.whl", hash = "sha256:3a1c0d837c0e5a32e415f821b36cf758eb92d510e6beff8fbfe4fa16573d93d6", size = 74446, upload-time = "2025-09-03T16:30:21.397Z" },
+    { url = "https://files.pythonhosted.org/packages/78/8c/ae74b17ea1672844a14c176a88f6d2718fa2c10948dc8401824d62265e9e/cron_descriptor-2.0.8-py3-none-any.whl", hash = "sha256:21fae0e6e0e28b19fd6a08e032c700077fe759e9bc1deb1ebe32f277fbc8ba6c", size = 74703, upload-time = "2026-03-23T13:19:16.486Z" },
 ]
 
 [[package]]
@@ -560,16 +560,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.12"
+version = "5.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b9445fc0695b03746f355c05b2eecc54c34e05198c686f4fc4406b722b52/django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb", size = 10860574, upload-time = "2026-03-03T13:56:05.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/32/4b144e125678efccf5d5b61581de1c4088d6b0286e46096e3b8de0d556c8/django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7", size = 8310245, upload-time = "2026-03-03T13:56:01.174Z" },
+    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
 ]
 
 [[package]]
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "django-oauth-toolkit"
-version = "3.1.0"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -612,9 +612,9 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/9f/2f183535b1ae1e3b6b07b59e74e75c47c057a690a83cc7ed1edc2621f3a4/django_oauth_toolkit-3.1.0.tar.gz", hash = "sha256:d5a59d07588cfefa8818e99d65040a252eb2ede22512483e2240c91d0b885c8e", size = 102563, upload-time = "2025-10-03T16:12:25.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/95/efd83b35c34b86eb2249d2b54c5eaf383c48f3f19034aa6f3807e37471b6/django_oauth_toolkit-3.2.0.tar.gz", hash = "sha256:c36761ae6810083d95a652e9c820046cde0d45a2e2a5574bbe7202656ec20bb6", size = 114211, upload-time = "2026-01-08T22:03:13.311Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/40/c36397edbd020319403a76ce3229f757c262db8652a424f354d848799271/django_oauth_toolkit-3.1.0-py3-none-any.whl", hash = "sha256:10ddc90804297d913dfb958edd58d5fac541eb1ca912f47893ca1e482bb2a11f", size = 78658, upload-time = "2025-10-03T16:12:24.038Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/cc/f27a784c0ecd13335abd9ef85ebb80dbc04945f919da5f496f56e3562751/django_oauth_toolkit-3.2.0-py3-none-any.whl", hash = "sha256:bd2cd2719b010231a2f370f927dbcc740454fb1d0dd7e7f4138f36227363dc26", size = 87077, upload-time = "2026-01-08T22:03:12.123Z" },
 ]
 
 [[package]]
@@ -764,23 +764,23 @@ wheels = [
 
 [[package]]
 name = "gunicorn"
-version = "25.1.0"
+version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -830,15 +830,15 @@ wheels = [
 
 [[package]]
 name = "jwcrypto"
-version = "1.5.6"
+version = "1.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/db/870e5d5fb311b0bcf049630b5ba3abca2d339fd5e13ba175b4c13b456d08/jwcrypto-1.5.6.tar.gz", hash = "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039", size = 87168, upload-time = "2024-03-06T19:58:31.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/90/f065668004d22715c1940d6e88e4c3afc8ee16d5664e4478d2c8fd23a250/jwcrypto-1.5.7.tar.gz", hash = "sha256:70204d7cca406eda8c82352e3c41ba2d946610dafd19e54403f0a1f4f18633c6", size = 89535, upload-time = "2026-04-07T00:35:36.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/58/4a1880ea64032185e9ae9f63940c9327c6952d5584ea544a8f66972f2fda/jwcrypto-1.5.6-py3-none-any.whl", hash = "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789", size = 92520, upload-time = "2024-03-06T19:58:29.765Z" },
+    { url = "https://files.pythonhosted.org/packages/72/24/fb7da4d6613de7001feaf540d4b5969c6b5a1c42839043b0196cb13aa057/jwcrypto-1.5.7-py3-none-any.whl", hash = "sha256:729463fefe28b6de5cf1ebfda3e94f1a1b41d2799148ef98a01cb9678ebe2bb0", size = 94799, upload-time = "2026-04-07T00:35:35.085Z" },
 ]
 
 [[package]]
@@ -858,64 +858,64 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.0.2"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
-    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
-    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
-    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
-    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
-    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
-    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
-    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
-    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
-    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
-    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
-    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
-    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "nexuslims-cdcs"
-version = "3.20.0+nx0"
+version = "3.21.0+nx0"
 source = { editable = "." }
 dependencies = [
     { name = "celery" },
@@ -969,27 +969,27 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery" },
-    { name = "core-composer-app", specifier = "==2.20.*" },
-    { name = "core-curate-app", specifier = "==2.20.*" },
-    { name = "core-dashboard-app", specifier = "==2.20.*" },
-    { name = "core-dashboard-common-app", specifier = "==2.20.*" },
-    { name = "core-explore-example-app", specifier = "==2.20.*" },
-    { name = "core-explore-federated-search-app", specifier = "==2.20.*" },
-    { name = "core-explore-keyword-app", specifier = "==2.20.*" },
-    { name = "core-exporters-app", specifier = "==2.20.*" },
-    { name = "core-federated-search-app", specifier = "==2.20.*" },
-    { name = "core-file-preview-app", specifier = "==2.20.*" },
-    { name = "core-linked-records-app", specifier = "==2.20.*" },
-    { name = "core-main-app", extras = ["auth"], specifier = "==2.20.*" },
-    { name = "core-module-advanced-blob-host-app", specifier = "==2.20.*" },
-    { name = "core-module-blob-host-app", specifier = "==2.20.*" },
-    { name = "core-module-chemical-composition-app", specifier = "==2.20.*" },
-    { name = "core-module-chemical-composition-simple-app", specifier = "==2.20.*" },
-    { name = "core-module-excel-uploader-app", specifier = "==2.20.*" },
-    { name = "core-module-periodic-table-app", specifier = "==2.20.*" },
-    { name = "core-module-remote-blob-host-app", specifier = "==2.20.*" },
-    { name = "core-module-text-area-app", specifier = "==2.20.*" },
-    { name = "core-website-app", specifier = "==2.20.*" },
+    { name = "core-composer-app", specifier = "==2.21.*" },
+    { name = "core-curate-app", specifier = "==2.21.*" },
+    { name = "core-dashboard-app", specifier = "==2.21.*" },
+    { name = "core-dashboard-common-app", specifier = "==2.21.*" },
+    { name = "core-explore-example-app", specifier = "==2.21.*" },
+    { name = "core-explore-federated-search-app", specifier = "==2.21.*" },
+    { name = "core-explore-keyword-app", specifier = "==2.21.*" },
+    { name = "core-exporters-app", specifier = "==2.21.*" },
+    { name = "core-federated-search-app", specifier = "==2.21.*" },
+    { name = "core-file-preview-app", specifier = "==2.21.*" },
+    { name = "core-linked-records-app", specifier = "==2.21.*" },
+    { name = "core-main-app", extras = ["auth"], specifier = "==2.21.*" },
+    { name = "core-module-advanced-blob-host-app", specifier = "==2.21.*" },
+    { name = "core-module-blob-host-app", specifier = "==2.21.*" },
+    { name = "core-module-chemical-composition-app", specifier = "==2.21.*" },
+    { name = "core-module-chemical-composition-simple-app", specifier = "==2.21.*" },
+    { name = "core-module-excel-uploader-app", specifier = "==2.21.*" },
+    { name = "core-module-periodic-table-app", specifier = "==2.21.*" },
+    { name = "core-module-remote-blob-host-app", specifier = "==2.21.*" },
+    { name = "core-module-text-area-app", specifier = "==2.21.*" },
+    { name = "core-website-app", specifier = "==2.21.*" },
     { name = "django" },
     { name = "django-redis" },
     { name = "gunicorn", extras = ["gthread"] },
@@ -1011,69 +1011,69 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d0/bebb3ffbf31c5a8e97241476c4cf8b9828954693ce6744b4a2326af3e16b/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:417423db963cb4be8bac3fc1204fe61610f6abeed1580a7a2cbb2fbda20f12af", size = 4062652, upload-time = "2026-02-11T04:21:53.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c0/0e16fb0addda4851445c28f8350d8c512f09de27bbb0d6d0bbf8b6709605/pillow-12.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:b957b71c6b2387610f556a7eb0828afbe40b4a98036fc0d2acfa5a44a0c2036f", size = 4138823, upload-time = "2026-02-11T04:22:03.088Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fb/6170ec655d6f6bb6630a013dd7cf7bc218423d7b5fa9071bf63dc32175ae/pillow-12.1.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:097690ba1f2efdeb165a20469d59d8bb03c55fb6621eb2041a060ae8ea3e9642", size = 3601143, upload-time = "2026-02-11T04:22:04.909Z" },
-    { url = "https://files.pythonhosted.org/packages/59/04/dc5c3f297510ba9a6837cbb318b87dd2b8f73eb41a43cc63767f65cb599c/pillow-12.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2815a87ab27848db0321fb78c7f0b2c8649dee134b7f2b80c6a45c6831d75ccd", size = 5266254, upload-time = "2026-02-11T04:22:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/05/30/5db1236b0d6313f03ebf97f5e17cda9ca060f524b2fcc875149a8360b21c/pillow-12.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f7ed2c6543bad5a7d5530eb9e78c53132f93dfa44a28492db88b41cdab885202", size = 4657499, upload-time = "2026-02-11T04:22:09.613Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/008d2ca0eb612e81968e8be0bbae5051efba24d52debf930126d7eaacbba/pillow-12.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:652a2c9ccfb556235b2b501a3a7cf3742148cd22e04b5625c5fe057ea3e3191f", size = 6232137, upload-time = "2026-02-11T04:22:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f1/f14d5b8eeb4b2cd62b9f9f847eb6605f103df89ef619ac68f92f748614ea/pillow-12.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d6e4571eedf43af33d0fc233a382a76e849badbccdf1ac438841308652a08e1f", size = 8042721, upload-time = "2026-02-11T04:22:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/d6/17824509146e4babbdabf04d8171491fa9d776f7061ff6e727522df9bd03/pillow-12.1.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b574c51cf7d5d62e9be37ba446224b59a2da26dc4c1bb2ecbe936a4fb1a7cb7f", size = 6347798, upload-time = "2026-02-11T04:22:15.449Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ee/c85a38a9ab92037a75615aba572c85ea51e605265036e00c5b67dfafbfe2/pillow-12.1.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a37691702ed687799de29a518d63d4682d9016932db66d4e90c345831b02fb4e", size = 7039315, upload-time = "2026-02-11T04:22:17.24Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f3/bc8ccc6e08a148290d7523bde4d9a0d6c981db34631390dc6e6ec34cacf6/pillow-12.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f95c00d5d6700b2b890479664a06e754974848afaae5e21beb4d83c106923fd0", size = 6462360, upload-time = "2026-02-11T04:22:19.111Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ab/69a42656adb1d0665ab051eec58a41f169ad295cf81ad45406963105408f/pillow-12.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:559b38da23606e68681337ad74622c4dbba02254fc9cb4488a305dd5975c7eeb", size = 7165438, upload-time = "2026-02-11T04:22:21.041Z" },
-    { url = "https://files.pythonhosted.org/packages/02/46/81f7aa8941873f0f01d4b55cc543b0a3d03ec2ee30d617a0448bf6bd6dec/pillow-12.1.1-cp314-cp314-win32.whl", hash = "sha256:03edcc34d688572014ff223c125a3f77fb08091e4607e7745002fc214070b35f", size = 6431503, upload-time = "2026-02-11T04:22:22.833Z" },
-    { url = "https://files.pythonhosted.org/packages/40/72/4c245f7d1044b67affc7f134a09ea619d4895333d35322b775b928180044/pillow-12.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:50480dcd74fa63b8e78235957d302d98d98d82ccbfac4c7e12108ba9ecbdba15", size = 7176748, upload-time = "2026-02-11T04:22:24.64Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ad/8a87bdbe038c5c698736e3348af5c2194ffb872ea52f11894c95f9305435/pillow-12.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:5cb1785d97b0c3d1d1a16bc1d710c4a0049daefc4935f3a8f31f827f4d3d2e7f", size = 2544314, upload-time = "2026-02-11T04:22:26.685Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/9d/efd18493f9de13b87ede7c47e69184b9e859e4427225ea962e32e56a49bc/pillow-12.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1f90cff8aa76835cba5769f0b3121a22bd4eb9e6884cfe338216e557a9a548b8", size = 5268612, upload-time = "2026-02-11T04:22:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f1/4f42eb2b388eb2ffc660dcb7f7b556c1015c53ebd5f7f754965ef997585b/pillow-12.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f1be78ce9466a7ee64bfda57bdba0f7cc499d9794d518b854816c41bf0aa4e9", size = 4660567, upload-time = "2026-02-11T04:22:31.799Z" },
-    { url = "https://files.pythonhosted.org/packages/01/54/df6ef130fa43e4b82e32624a7b821a2be1c5653a5fdad8469687a7db4e00/pillow-12.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:42fc1f4677106188ad9a55562bbade416f8b55456f522430fadab3cef7cd4e60", size = 6269951, upload-time = "2026-02-11T04:22:33.921Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/48/618752d06cc44bb4aae8ce0cd4e6426871929ed7b46215638088270d9b34/pillow-12.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98edb152429ab62a1818039744d8fbb3ccab98a7c29fc3d5fcef158f3f1f68b7", size = 8074769, upload-time = "2026-02-11T04:22:35.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/bd/f1d71eb39a72fa088d938655afba3e00b38018d052752f435838961127d8/pillow-12.1.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d470ab1178551dd17fdba0fef463359c41aaa613cdcd7ff8373f54be629f9f8f", size = 6381358, upload-time = "2026-02-11T04:22:37.698Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ef/c784e20b96674ed36a5af839305f55616f8b4f8aa8eeccf8531a6e312243/pillow-12.1.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6408a7b064595afcab0a49393a413732a35788f2a5092fdc6266952ed67de586", size = 7068558, upload-time = "2026-02-11T04:22:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/73/cb/8059688b74422ae61278202c4e1ad992e8a2e7375227be0a21c6b87ca8d5/pillow-12.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5d8c41325b382c07799a3682c1c258469ea2ff97103c53717b7893862d0c98ce", size = 6493028, upload-time = "2026-02-11T04:22:42.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/da/e3c008ed7d2dd1f905b15949325934510b9d1931e5df999bb15972756818/pillow-12.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7697918b5be27424e9ce568193efd13d925c4481dd364e43f5dff72d33e10f8", size = 7191940, upload-time = "2026-02-11T04:22:44.543Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
 ]
 
 [[package]]
@@ -1090,32 +1090,32 @@ wheels = [
 
 [[package]]
 name = "psycopg2-binary"
-version = "2.9.11"
+version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e1/c2b38d256d0dafd32713e9f31982a5b028f4a3651f446be70785f484f472/psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee", size = 3864529, upload-time = "2025-10-10T11:12:36.791Z" },
-    { url = "https://files.pythonhosted.org/packages/11/32/b2ffe8f3853c181e88f0a157c5fb4e383102238d73c52ac6d93a5c8bffe6/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0", size = 4411242, upload-time = "2025-10-10T11:12:42.388Z" },
-    { url = "https://files.pythonhosted.org/packages/10/04/6ca7477e6160ae258dc96f67c371157776564679aefd247b66f4661501a2/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766", size = 4468258, upload-time = "2025-10-10T11:12:48.654Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/7e/6a1a38f86412df101435809f225d57c1a021307dd0689f7a5e7fe83588b1/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3", size = 4166295, upload-time = "2025-10-10T11:12:52.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7d/c07374c501b45f3579a9eb761cbf2604ddef3d96ad48679112c2c5aa9c25/psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f", size = 3983133, upload-time = "2025-10-30T02:55:24.329Z" },
-    { url = "https://files.pythonhosted.org/packages/82/56/993b7104cb8345ad7d4516538ccf8f0d0ac640b1ebd8c754a7b024e76878/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4", size = 3652383, upload-time = "2025-10-10T11:12:56.387Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ac/eaeb6029362fd8d454a27374d84c6866c82c33bfc24587b4face5a8e43ef/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c", size = 3298168, upload-time = "2025-10-10T11:13:00.403Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/50c3facc66bded9ada5cbc0de867499a703dc6bca6be03070b4e3b65da6c/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60", size = 3044712, upload-time = "2025-10-30T02:55:27.975Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8e/b7de019a1f562f72ada81081a12823d3c1590bedc48d7d2559410a2763fe/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1", size = 3347549, upload-time = "2025-10-10T11:13:03.971Z" },
-    { url = "https://files.pythonhosted.org/packages/80/2d/1bb683f64737bbb1f86c82b7359db1eb2be4e2c0c13b947f80efefa7d3e5/psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa", size = 2714215, upload-time = "2025-10-10T11:13:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a9/9d55c614a891288f15ca4b5209b09f0f01e3124056924e17b81b9fa054cc/psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f", size = 3864755, upload-time = "2025-10-10T11:13:17.727Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
-    { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
-    { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
-    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
 ]
 
 [[package]]
@@ -1363,11 +1363,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]
@@ -1381,11 +1381,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1405,11 +1405,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]
 
 [[package]]
@@ -1423,13 +1423,13 @@ wheels = [
 
 [[package]]
 name = "xml-utils"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/7f/69f371e249548c01ebf02ed38b2cdee2906c9484d2e9ef33bbfae8b60bd6/xml_utils-1.23.0.tar.gz", hash = "sha256:d10411c42b4b7caebd61eebf0f26a9b826b5e1f3d580ee9d8597a9484b1d7277", size = 19875, upload-time = "2026-01-23T18:04:10.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/dd/1614b256550c3d92dcbc6fd51bd347dccc59f269cb158ebd954b04c6e80e/xml_utils-1.23.1.tar.gz", hash = "sha256:ed3a23b4dccbc72ee4c5fc4a53f21f46512dca08569d2629553b1b254b2c7514", size = 19918, upload-time = "2026-04-22T15:55:00.308Z" }
 
 [[package]]
 name = "xmlschema"


### PR DESCRIPTION
## Summary

- Upgrades the underlying CDCS/MDCS base from 3.20.0 to 3.21.0 by bumping all `core_*_app` packages from `2.20.*` to `2.21.*` and regenerating `uv.lock`
- Applies all functional (non-cosmetic) upstream changes to our locally overridden files (settings, views, URLs, scripts, etc.)
- Applies `ruff` formatting to all Python source files to align with upstream style
- Adds a new `.claude/commands/upgrade-base-cdcs.md` slash command that automates future CDCS base upgrades

## Changes

### CDCS 3.21.0 Upgrade (`32cdb9c`)
- Updated `pyproject.toml`: all 21 `core_*_app` packages bumped from `2.20.*` → `2.21.*`
- Regenerated `uv.lock` with resolved 3.21.0 dependency tree
- Merged upstream functional changes into overridden files: `mdcs/settings.py`, `mdcs/core_settings.py`, `mdcs/urls.py`, `nexuslims_overrides/views.py`, `nexuslims_overrides/menus.py`, `nexuslims_overrides/context_processors.py`, `nexuslims_overrides/middleware.py`, deployment scripts, etc.
- Updated `nexuslims_annotate/views.py` and tests to reflect upstream API changes
- Added `docs/changes/22.misc.md` changelog fragment

### Ruff formatting (`a28ad7a`)
- Auto-formatted all Python source files with `ruff format` to match upstream code style

### `/upgrade-base-cdcs` command (`39b8088`)
- New Claude Code slash command at `.claude/commands/upgrade-base-cdcs.md`
- Dynamically determines which local files override upstream MDCS files
- Checks upstream diffs between old and new CDCS versions for those files
- Reads release notes for all skipped intermediate versions
- Applies functional upstream changes and updates `pyproject.toml`, lockfile, and creates a changelog fragment

## Test plan

- [x] Run `uv run python runtests.py` and confirm all tests pass
- [x] Run `dev-build-clean && dev-up` and verify the application starts cleanly
- [x] Log in to the dev instance and confirm the dashboard, record list, and record detail pages all render correctly
- [ ] Verify blob upload works (upstream added a file extension validator in 3.21.0)
- [x] Confirm SSO login still functions