### PR TITLE
Preserve login redirects and improve gallery discovery

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -88,7 +88,7 @@ git pull
 
 ##### Rebuild Required
 (Include if Dockerfile / pyproject.toml / uv.lock changed)
-Python dependencies or the container definition changed. Rebuild before restarting:
+Python dependencies, files baked into the container (XSLT, schema, etc.) or the container definition changed. Rebuild before restarting:
 ```bash
 cd deployment
 source admin-commands.sh
@@ -108,11 +108,7 @@ Re-upload the updated stylesheets to the database after restarting:
 ```bash
 cd deployment
 source admin-commands.sh
-admin-init
-```
-Or to update only XSLT without a full re-init:
-```bash
-docker exec ${COMPOSE_PROJECT_NAME}_cdcs bash /srv/scripts/update-xslt.sh
+admin-update-xslt
 ```
 
 ##### Schema Updated
@@ -121,7 +117,7 @@ Re-upload the updated schema to the database:
 ```bash
 cd deployment
 source admin-commands.sh
-admin-init
+admin-upgrade-schema
 ```
 
 #### 4. Restart the stack

--- a/deployment/.env.prod.example
+++ b/deployment/.env.prod.example
@@ -161,8 +161,10 @@ NX_ENABLE_GALLERY=true
 NX_GALLERY_FACILITY_NAME=NexusLIMS
 # NX_GALLERY_ROTATION_INTERVAL: seconds between auto-advancing slides
 NX_GALLERY_ROTATION_INTERVAL=30
-# NX_GALLERY_LOGO: static file path for the top-right logo (e.g. nexuslims/img/logo.png)
-# Leave unset to fall back to NX_NAV_LOGO
+# NX_GALLERY_LOGO: static file path for the top-right logo, relative to the Django static root
+#   (e.g. nexuslims/img/logo.png). Place custom image files in config/static_files/ -- they will
+#   be collected into the static root on container startup (e.g. config/static_files/my_logo.png
+#   becomes "my_logo.png"). Leave unset to fall back to NX_NAV_LOGO.
 #NX_GALLERY_LOGO=
 
 # ----------------------------------------------------------------------------

--- a/docs/changes/22.misc.md
+++ b/docs/changes/22.misc.md
@@ -1,1 +1,0 @@
-Upgraded the underlying CDCS/MDCS base from version 3.20.0 to 3.21.0, bringing in the latest upstream improvements including an improved dashboard, a blob upload file extension validator, and various bug fixes and minor improvements.

--- a/nexuslims_overrides/context_processors.py
+++ b/nexuslims_overrides/context_processors.py
@@ -76,6 +76,10 @@ def nexuslims_features(request):
     return {
         "NX_ENABLE_TUTORIALS": getattr(settings, "NX_ENABLE_TUTORIALS", True),
         "NX_ENABLE_ANNOTATOR": getattr(settings, "NX_ENABLE_ANNOTATOR", True),
+        "NX_ENABLE_GALLERY": (
+            "nexuslims_gallery" in settings.INSTALLED_APPS
+            and getattr(settings, "NX_ENABLE_GALLERY", True)
+        ),
         "IS_PUBLIC_DEMO": getattr(settings, "IS_PUBLIC_DEMO", False),
     }
 

--- a/nexuslims_overrides/menus.py
+++ b/nexuslims_overrides/menus.py
@@ -28,16 +28,6 @@ for category in ["nodropdown", "explorer", "composer", "dashboard", "help", "use
 # NO DROPDOWN MENU - Top-level navigation items
 # ============================================================================
 
-Menu.add_item(
-    "nodropdown",
-    MenuItem(
-        "Browse and Search Records",
-        reverse("core_explore_keyword_app_search"),
-        icon="search",
-        iconClass="fas",
-    ),
-)
-
 # Custom menu links - configurable via settings
 # Set NX_CUSTOM_MENU_LINKS in settings.py as a list of dicts:
 # NX_CUSTOM_MENU_LINKS = [
@@ -149,12 +139,31 @@ Menu.add_item(
 )
 
 # ============================================================================
-# EXPLORER MENU - Commented out in 2.21.0, keeping empty
+# EXPLORER MENU
 # ============================================================================
-# Menu.add_item(
-#     "explorer",
-#     MenuItem("Search by Keyword", reverse("core_explore_keyword_app_search")),
-# )
+
+Menu.add_item(
+    "explorer",
+    MenuItem(
+        "Browse and Search Records",
+        reverse("core_explore_keyword_app_search"),
+        icon="search",
+        iconClass="fas",
+    ),
+)
+
+if "nexuslims_gallery" in settings.INSTALLED_APPS and getattr(
+    settings, "NX_ENABLE_GALLERY", True
+):
+    Menu.add_item(
+        "explorer",
+        MenuItem(
+            "Visual Gallery",
+            reverse("nexuslims_gallery_page"),
+            icon="images",
+            iconClass="fas",
+        ),
+    )
 
 # ============================================================================
 # COMPOSER MENU - Commented out in 2.21.0, keeping empty

--- a/nexuslims_overrides/settings.py
+++ b/nexuslims_overrides/settings.py
@@ -54,12 +54,11 @@ NX_XSLT_DEBUG = False
 # ============================================================================
 
 NX_HOMEPAGE_TEXT = (
-    "This laboratory information management system (LIMS) allows for the "
-    "automated creation and curation of microscopy experimental records using "
-    "the schema co-developed by ODI and the MML Electron Microscopy Nexus Facility. "
-    "Experimental records are automatically harvested from multiple data sources to "
-    "facilitate browsing and searching of data collected from the varied instruments "
-    "in the Nexus Facility."
+    "NexusLIMS automates the creation and curation of microscopy experimental "
+    "records by harvesting data and metadata from multiple sources. It organizes "
+    "experimental information into structured, searchable records that make it "
+    "easier to find, understand, and share data collected across a facility's "
+    "instruments."
 )
 
 NX_HOMEPAGE_LOGO = "nexuslims/img/logo_stacked_modern.png"  # Path relative to static/

--- a/nexuslims_overrides/static/nexuslims/css/homepage.css
+++ b/nexuslims_overrides/static/nexuslims/css/homepage.css
@@ -32,7 +32,46 @@
     font-weight: 500;
 }
 
-/* tiles css */
+/* Public demo feature summary */
+.nx-demo-feature-card {
+    min-height: 0;
+}
+
+.nx-demo-feature-body {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: 0.7rem;
+    align-items: start;
+    padding: 0.85rem 1rem !important;
+}
+
+.nx-demo-feature-icon {
+    width: 2rem;
+    margin-top: 0.15rem;
+    font-size: 1.35rem;
+    line-height: 1;
+    text-align: center;
+}
+
+.nx-demo-feature-copy {
+    min-width: 0;
+}
+
+.nx-demo-feature-title {
+    margin: 0 0 0.35rem;
+    color: #3f454b;
+    font-size: 1rem;
+    font-weight: 650;
+    line-height: 1.3;
+}
+
+.nx-demo-feature-description {
+    margin: 0;
+    color: #6c757d;
+    font-size: 0.875rem;
+    line-height: 1.45;
+    text-align: left;
+}
 
 /* Media queries for responsive layout */
 @media (max-width: 767.98px) {
@@ -46,55 +85,119 @@
     #homepage-logo-col {
         display: none;
     }
+
+    .tile-link {
+        padding: 1.25rem;
+    }
 }
 
-.tile .icon {
-    background-color: var(--nx-primary-color, #11659c);
-    background-image: -moz-linear-gradient(center top , rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15)), url("../img/bg01.png");
-    border-radius: 100%;
-    box-shadow: 0 0 0 7px white, 0 0 0 8px #e0e0e0;
-    color: #fff;
-    cursor: default;
-    display: inline-block;
-    height: 2em;
-    line-height: 2em;
-    margin: 0.5em 0.75em 0.25em 0.25em;
-    width: 2em;
-    font-size: 2em;
-
-    float: left;
-    text-align: center;
+/* Homepage action cards */
+#tiles {
+    margin-top: 1.5rem;
 }
 
 .tile {
-    display: inline-block;
     width: 100%;
-    border-radius: 20px;
-    background-color: inherit;
-    padding: 0px 30px;
-    transition: all 0.3s ease-in-out;
+    overflow: hidden;
+    border: 1px solid #e1e7ec;
+    border-radius: 14px;
+    background: #fff;
+    box-shadow: 0 3px 12px rgba(20, 45, 70, 0.07);
+    transition:
+        border-color 0.2s ease,
+        box-shadow 0.2s ease,
+        transform 0.2s ease;
 }
 
-.tile a > i {
-    color: white;
+.tile:hover {
+    border-color: color-mix(
+        in srgb,
+        var(--nx-primary-color, #11659c) 35%,
+        #e1e7ec
+    );
+    box-shadow: 0 9px 24px rgba(20, 45, 70, 0.13);
+    transform: translateY(-2px);
 }
 
-.tile a:hover {
-    color: var(--nx-primary-color)
+.tile-link {
+    display: flex;
+    align-items: center;
+    gap: 1.1rem;
+    min-height: 9rem;
+    padding: 1.5rem;
+    color: inherit;
+    text-decoration: none;
 }
 
-.tile a div.icon {
-    cursor: pointer;
+.tile-link:hover,
+.tile-link:focus {
+    color: inherit;
+    text-decoration: none;
 }
 
-.tile a div.icon:hover {
-    background-color: #f5c636;
-    color: #333;
-    transition: all 0.3s ease-in-out;
+.tile-link:focus-visible {
+    outline: 3px solid var(--nx-warning-color, #f5c636);
+    outline-offset: -3px;
 }
 
-.tile a div.icon:hover + a {
-    background-color: #f5c636;
-    color: #333;
-    transition: all 0.3s ease-in-out;
+.tile .icon {
+    display: inline-flex;
+    flex: 0 0 4rem;
+    align-items: center;
+    justify-content: center;
+    width: 4rem;
+    height: 4rem;
+    border-radius: 12px;
+    background: color-mix(
+        in srgb,
+        var(--nx-primary-color, #11659c) 12%,
+        white
+    );
+    color: var(--nx-primary-color, #11659c);
+    font-size: 1.8rem;
+    transition:
+        background-color 0.2s ease,
+        color 0.2s ease;
+}
+
+.tile:hover .icon {
+    background: var(--nx-primary-color, #11659c);
+    color: #fff;
+}
+
+.tile .text {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+    margin: 0;
+    text-align: left;
+}
+
+.tile-title {
+    color: var(--nx-primary-color, #11659c);
+    font-size: 1.2rem;
+    font-weight: 650;
+    line-height: 1.25;
+}
+
+.tile-description {
+    color: #5d6872;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.tile-arrow {
+    flex: 0 0 auto;
+    color: #9aa5ae;
+    font-size: 1rem;
+    transition:
+        color 0.2s ease,
+        transform 0.2s ease;
+}
+
+.tile:hover .tile-arrow {
+    color: var(--nx-primary-color, #11659c);
+    transform: translateX(3px);
 }

--- a/nexuslims_overrides/static/nexuslims/js/tiles.js
+++ b/nexuslims_overrides/static/nexuslims/js/tiles.js
@@ -13,34 +13,6 @@
 
         // jQuery is loaded, proceed
         jQuery(document).ready(function($) {
-          // Read colors from CSS custom properties (set by Django settings)
-          var rootStyles = getComputedStyle(document.documentElement);
-          var yellow = rootStyles.getPropertyValue('--nx-warning-color').trim() || '#f5c636';
-          console.log("yellow", yellow);
-          var black = rootStyles.getPropertyValue('--nx-dark-gray').trim() || '#333';
-          console.log("black", black);
-          var blue = rootStyles.getPropertyValue('--nx-primary-color').trim() || '#11659c';
-          console.log("blue", blue);
-
-            // Use event delegation on document to handle dynamically loaded tiles
-            $(document).on('mouseenter', '.tile', function() {
-                $(this).css({'cursor': 'pointer',
-                             'background-color': '#efefef'});
-                $('.icon', this).css({'background-color': yellow,
-                                'color': black,
-                                'transition': 'all 0.3s ease-in-out'});
-                $('.text h3', this).css({'color': blue});
-            });
-
-            $(document).on('mouseleave', '.tile', function() {
-                // on mouseout, reset the background colour
-                $('.icon', this).css({'background-color': blue,
-                                'color': '#fff'});
-                $('.text h3', this).css({'color': black});
-                $(this).css({'cursor': 'inherit',
-                             'background-color': 'inherit'});
-            });
-
             // Make entire tile clickable
             $(document).on('click', '.tile', function(){
                 var link = $(this).find('a').first().attr('href');

--- a/nexuslims_overrides/static/nexuslims/js/tour.js
+++ b/nexuslims_overrides/static/nexuslims/js/tour.js
@@ -291,6 +291,7 @@
 
         // Check viewport at tour creation time
         var mobile = isMobileView();
+        var galleryEnabled = $('#visual_gallery').length > 0;
 
         tour.addStep({
             id: 'welcome',
@@ -398,18 +399,55 @@
                 buttons: [buttons.back(true), buttons.next]
             });
 
+            if (galleryEnabled) {
+                tour.addStep({
+                    id: 'tut-visual-gallery',
+                    title: 'Visual Gallery',
+                    text: 'Open the visual gallery to browse featured dataset images from across the NexusLIMS record repository.',
+                    attachTo: {
+                        element: '#visual_gallery',
+                        on: 'top'
+                    },
+                    buttons: [buttons.back(true), buttons.next]
+                });
+            }
+
             tour.addStep({
                 id: 'get-started',
                 title: 'Get Started!',
-                text: 'That\'s it! Click the "Browse and Search Records" link to explore experimental data, or close this tutorial to continue exploring the homepage.',
+                text: galleryEnabled
+                    ? 'That\'s it! Browse and search experimental records or open the visual gallery to explore featured datasets.'
+                    : 'That\'s it! Click the "Browse and Search Records" link to explore experimental data, or close this tutorial to continue exploring the homepage.',
                 buttons: [buttons.back(true), buttons.end]
             });
         } else {
             // Desktop-specific steps
+            function openExploreDropdown() {
+                var dropdownEl = document.getElementById('dropdownExploration');
+                if (dropdownEl && typeof bootstrap !== 'undefined') {
+                    var dropdown = bootstrap.Dropdown.getOrCreateInstance(dropdownEl);
+                    dropdown.show();
+                }
+            }
+
+            function closeExploreDropdown() {
+                var dropdownEl = document.getElementById('dropdownExploration');
+                if (dropdownEl && typeof bootstrap !== 'undefined') {
+                    var dropdown = bootstrap.Dropdown.getInstance(dropdownEl);
+                    if (dropdown) {
+                        dropdown.hide();
+                    }
+                }
+            }
+
             tour.addStep({
                 id: 'browse-link',
                 title: 'Browse Records',
                 text: 'Click here to browse and search all experimental records in the system. You can filter by keywords, instruments, dates, and more.',
+                beforeShowPromise: function() {
+                    openExploreDropdown();
+                    return Promise.resolve();
+                },
                 attachTo: {
                     element: '#nav a[href*="explore/keyword"]',
                     on: 'bottom'
@@ -421,12 +459,29 @@
                 id: 'tut-browse-records-tile',
                 title: 'Browse Records',
                 text: 'You can also access the record browser through the link below',
+                beforeShowPromise: function() {
+                    closeExploreDropdown();
+                    return Promise.resolve();
+                },
                 attachTo: {
                     element: '#app_search',
                     on: 'top'
                 },
                 buttons: [buttons.back(true), buttons.next]
             });
+
+            if (galleryEnabled) {
+                tour.addStep({
+                    id: 'tut-visual-gallery',
+                    title: 'Visual Gallery',
+                    text: 'Open the visual gallery to browse featured dataset images from across the NexusLIMS record repository.',
+                    attachTo: {
+                        element: '#visual_gallery',
+                        on: 'top'
+                    },
+                    buttons: [buttons.back(true), buttons.next]
+                });
+            }
 
             tour.addStep({
                 id: 'tut-tutorial',
@@ -500,7 +555,9 @@
             tour.addStep({
                 id: 'get-started',
                 title: 'Get Started!',
-                text: 'That\'s it! Click the "Browse and Search Records" link to explore experimental data, or close this tutorial to continue exploring the homepage.',
+                text: galleryEnabled
+                    ? 'That\'s it! Browse and search experimental records or open the visual gallery to explore featured datasets.'
+                    : 'That\'s it! Click the "Browse and Search Records" link to explore experimental data, or close this tutorial to continue exploring the homepage.',
                 beforeShowPromise: () => {
                     closeHelpDropdown();
                     return Promise.resolve();
@@ -508,9 +565,15 @@
                 buttons: [buttons.back(true), buttons.end]
             });
 
-            // Cleanup: close dropdown when tour ends (desktop only)
-            tour.on('complete', closeHelpDropdown);
-            tour.on('cancel', closeHelpDropdown);
+            // Cleanup: close dropdowns when tour ends (desktop only)
+            tour.on('complete', function() {
+                closeExploreDropdown();
+                closeHelpDropdown();
+            });
+            tour.on('cancel', function() {
+                closeExploreDropdown();
+                closeHelpDropdown();
+            });
         }
 
         // Cleanup: close navPanel when tour ends (mobile)

--- a/nexuslims_overrides/templates/core_main_app/user/homepage.html
+++ b/nexuslims_overrides/templates/core_main_app/user/homepage.html
@@ -3,6 +3,7 @@
 
 {# NexusLIMS Homepage Template #}
 {# Migrated from templates/core_main_app/user/homepage.html #}
+<link rel="stylesheet" href="{% static 'nexuslims/css/homepage.css' %}">
 
 {% if IS_PUBLIC_DEMO %}
 <div class="row align-items-center rounded mb-2" id="intro"
@@ -23,6 +24,12 @@
                class="btn btn-light btn-lg fw-semibold">
                 <i class="fas fa-search me-1"></i> Browse demo records
             </a>
+            {% if NX_ENABLE_GALLERY %}
+            <a href="{% url 'nexuslims_gallery_page' %}"
+               class="btn btn-light btn-lg fw-semibold">
+                <i class="fas fa-images me-1"></i> Visual gallery
+            </a>
+            {% endif %}
             <a href="https://datasophos.github.io/NexusLIMS/stable/frontend_guide.html" target="_blank" rel="noopener noreferrer"
                class="btn btn-light btn-lg fw-semibold">
                 <i class="fas fa-book me-1"></i> Learn more
@@ -55,8 +62,7 @@
                 {% endif %}
                 {% if NX_DOCUMENTATION_LINK %}visit the
                 <a href="{{ NX_DOCUMENTATION_LINK }}" target="_blank">documentation page</a>{% endif %}.
-                To get started, please click the link below to start
-                browsing experimental records:
+                To get started, use the links below to explore experimental records.
             </p>
         </div>
         <div id="homepage-logo-col" class="col-md-3">

--- a/nexuslims_overrides/templates/core_main_app/user/login/main.html
+++ b/nexuslims_overrides/templates/core_main_app/user/login/main.html
@@ -1,0 +1,58 @@
+<div class="form-login">
+    {% if data.ENABLE_SAML2_SSO_AUTH %}
+    <h3><div class="text-center" style="margin: 1em;">Sign in with:</div></h3>
+    <div class="text-center">
+        <a href="{% url 'core_main_app_saml2_login' %}?next={{ request.GET.next|urlencode }}"
+           class="p-2 btn btn-primary text-center">
+            <i class="fas fa-globe"></i> Single Sign-on
+        </a>
+    </div>
+    <h3><div class="text-center" style="margin: 1em;">Or:</div></h3>
+    {% else %}
+    <h3><div class="text-center" style="margin: 1em;">Sign in</div></h3>
+    {% endif %}
+    {% if data.login_error %}
+    <div class="alert alert-danger">
+        <i class="fas fa-exclamation-circle"></i> Invalid username and/or password. Please try again or
+        contact an administrator for any assistance.
+    </div>
+    {% endif %}
+    {% if data.login_locked %}
+    <div class="alert alert-info">
+        <i class="fas fa-info-circle"></i> Your username is not activated yet. Please check back soon or
+        contact an administrator for any assistance.
+    </div>
+    {% endif %}
+
+    <form method="post" action="{% url 'core_main_app_login' %}" class="form-horizontal">
+        {% csrf_token %}
+        {% for field in data.login_form.visible_fields %}
+        <div class="form-group">
+            <div>
+                {{ field }}
+            </div>
+        </div>
+        {% endfor %}
+
+        {% for field in data.login_form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+
+        <div class="form-group">
+            <div class=" {% if BOOTSTRAP_VERSION|first == "4" %}float-right{% elif BOOTSTRAP_VERSION|first == "5"  %}float-end{% endif %} ">
+                <a href="{% url 'password_reset' %}">
+                    <i class="fas fa-lock" aria-hidden="true"></i> Forgot password?&nbsp;
+                </a>
+
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-arrow-right-to-bracket"></i> Login
+                </button>
+            </div>
+        </div>
+        {% if data.with_website_features %}
+        <div class="text-center" style="margin-top: 5em;">
+            <p>No account? <a href="{% url 'core_website_app_account_request' %}">Request one</a></p>
+        </div>
+        {% endif %}
+    </form>
+</div>

--- a/nexuslims_overrides/templates/mdcs_home/tiles.html
+++ b/nexuslims_overrides/templates/mdcs_home/tiles.html
@@ -13,40 +13,72 @@
 
 <section class="nx-demo-features mb-4">
     <h6 class="text-uppercase text-muted fw-semibold mb-3 mt-2" style="letter-spacing: 0.08em;">NexusLIMS Features:</h6>
-    <div class="row g-3">
-        <div class="col-sm-6 col-lg-3">
-            <div class="card h-100 border-0 shadow-sm text-center p-3">
-                <div class="card-body">
-                    <i class="fas fa-th-list fa-2x text-primary mb-2"></i>
-                    <h5 class="card-title">Browse Records</h5>
-                    <p class="card-text text-muted small">Explore your facility's experiment records with full metadata and dataset previews.</p>
+    <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-2">
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-sync-alt text-info nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Automated Data Harvesting</h5>
+                        <p class="nx-demo-feature-description">Turn instrument data and metadata into structured records automatically.</p>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col-sm-6 col-lg-3">
-            <div class="card h-100 border-0 shadow-sm text-center p-3">
-                <div class="card-body">
-                    <i class="fas fa-search fa-2x text-info mb-2"></i>
-                    <h5 class="card-title">Full-text Search</h5>
-                    <p class="card-text text-muted small">Search across all record metadata, sample names, researchers, and instrument types.</p>
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-th-list text-primary nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Browse Records</h5>
+                        <p class="nx-demo-feature-description">Explore experiment records with full metadata and dataset previews.</p>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col-sm-6 col-lg-3">
-            <div class="card h-100 border-0 shadow-sm text-center p-3">
-                <div class="card-body">
-                    <i class="fas fa-download fa-2x text-warning mb-2"></i>
-                    <h5 class="card-title">Download Files</h5>
-                    <p class="card-text text-muted small">Access instrument data files directly from record detail pages.</p>
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-search text-info nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Full-text Search</h5>
+                        <p class="nx-demo-feature-description">Search record metadata, sample names, researchers, and instruments.</p>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col-sm-6 col-lg-3">
-            <div class="card h-100 border-0 shadow-sm text-center p-3">
-                <div class="card-body">
-                    <i class="fas fa-pencil-alt fa-2x text-success mb-2"></i>
-                    <h5 class="card-title">Annotate Data Records</h5>
-                    <p class="card-text text-muted small">Easily add descriptions and organize datasets within records using the inline annotator.</p>
+        {% if NX_ENABLE_GALLERY %}
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-images text-primary nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Visual Gallery</h5>
+                        <p class="nx-demo-feature-description">Showcases featured datasets in a full-screen rotating display.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-download text-warning nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Download Files</h5>
+                        <p class="nx-demo-feature-description">Access instrument data files directly from record detail pages.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card h-100 border-0 shadow-sm nx-demo-feature-card">
+                <div class="card-body nx-demo-feature-body">
+                    <i class="fas fa-pencil-alt text-success nx-demo-feature-icon"></i>
+                    <div class="nx-demo-feature-copy">
+                        <h5 class="nx-demo-feature-title">Annotate Data Records</h5>
+                        <p class="nx-demo-feature-description">Add descriptions and organize datasets with the inline annotator.</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -55,18 +87,21 @@
 {% endif %}
 
 <!-- <h2 id="available-options">Available Options</h2> -->
-{% for tile in tiles %}
-<div class="tile" id="{{ tile.id }}">
-    <a href="{{ tile.link }}">
-        <div class="icon">
-            <i class="fas {{ tile.logo }}"></i>
+<div class="row g-3">
+    {% for tile in tiles %}
+    <div class="{% if tiles|length > 1 %}col-md-6{% else %}col-12{% endif %}">
+        <div class="tile h-100" id="{{ tile.id }}">
+            <a class="tile-link" href="{{ tile.link }}">
+                <span class="icon" aria-hidden="true">
+                    <i class="fas {{ tile.logo }}"></i>
+                </span>
+                <span class="text">
+                    <span class="tile-title">{{ tile.title }}</span>
+                    <span class="tile-description">{{ tile.text }}</span>
+                </span>
+                <i class="fas fa-arrow-right tile-arrow" aria-hidden="true"></i>
+            </a>
         </div>
-    </a>
-    <div class="text">
-        <h3><a href="{{ tile.link }}">{{ tile.title }}</a></h3>
-        <p>
-            {{ tile.text }}
-        </p>
     </div>
+    {% endfor %}
 </div>
-{% endfor %}

--- a/nexuslims_overrides/templates/theme/menu.html
+++ b/nexuslims_overrides/templates/theme/menu.html
@@ -17,17 +17,6 @@
         <!-- Start float left menu-->
         {% block navigation_menu %}
             {% generate_menu %}
-            {% for item in menus.nodropdown %}
-                <li>
-                    <a href="{{ item.url }}"{% if item|get_attribute:'id' %} id="{{ item.id }}"{% endif %}{% if item|get_attribute:'css_class' %} class="{{ item.css_class }}"{% endif %}>
-                        {% if item|get_attribute:'icon' %}<i class="{{ item.iconClass }} fa-{{ item.icon }} menu-fa"></i>{% endif %} {{ item.title }}
-                    </a>
-                </li>
-            {% endfor %}
-            {% comment %}
-            Explorer and Composer dropdowns are disabled in NexusLIMS.
-            Uncomment and add menu items in nexuslims_overrides/menus.py to enable.
-            {% endcomment %}
             {% if menus.explorer %}
             <li class="nested">
                 <div class="dropdown">
@@ -37,7 +26,7 @@
                        data-bs-toggle="dropdown"
                        aria-haspopup="true"
                        aria-expanded="false">
-                        Data Exploration
+                        <i class="fas fa-compass menu-fa"></i> Explore Data
                     </a>
                     <ul class="dropdown-menu"
                         aria-labelledby="dropdownExploration">
@@ -45,7 +34,7 @@
                         {% for item in menus.explorer %}
                             <li class="dropdown-item">
                                 <a href="{{ item.url }}">
-                                    {% if item|get_attribute:'icon' %}<i class="fas fa-{{ item.icon }}"></i>{% endif %} {{ item.title }}
+                                    {% if item|get_attribute:'icon' %}<i class="{{ item.iconClass }} fa-{{ item.icon }} menu-fa"></i>{% endif %} {{ item.title }}
                                 </a>
                             </li>
                         {% endfor %}
@@ -53,6 +42,13 @@
                 </div>
             </li>
             {% endif %}
+            {% for item in menus.nodropdown %}
+                <li>
+                    <a href="{{ item.url }}"{% if item|get_attribute:'id' %} id="{{ item.id }}"{% endif %}{% if item|get_attribute:'css_class' %} class="{{ item.css_class }}"{% endif %}>
+                        {% if item|get_attribute:'icon' %}<i class="{{ item.iconClass }} fa-{{ item.icon }} menu-fa"></i>{% endif %} {{ item.title }}
+                    </a>
+                </li>
+            {% endfor %}
             {% if menus.composer %}
             <li class="nested">
                 <div class="dropdown">
@@ -133,7 +129,7 @@
                     </ul>
                 </div>
             {% else %}
-                <a class="btn-custom" href="{% url LOGIN_URL %}">
+                <a class="btn-custom" href="{% url LOGIN_URL %}?next={{ request.get_full_path|urlencode }}">
                     <i class="fas fa-sign-in-alt menu-fa"></i> Log In / Sign Up
                 </a>
             {% endif %}

--- a/nexuslims_overrides/views.py
+++ b/nexuslims_overrides/views.py
@@ -21,10 +21,10 @@ def tiles(request):
     NexusLIMS customized tiles for homepage.
 
     Customizations from base mdcs_home.views.tiles():
-    - Reordered: Search first, then Curate
+    - Reordered: Search first, then Gallery
     - Disabled: "Build your own queries", "Compose a template"
     - Custom text: "Browse and Search Records" instead of "Search by keyword"
-    - Added IDs: "app_search" and "curator" for JavaScript targeting
+    - Added IDs for JavaScript targeting
     - NexusLIMS-specific descriptions
 
     :param request:
@@ -44,7 +44,20 @@ def tiles(request):
         }
         context["tiles"].append(explore_keywords_tile)
 
-    # Second tile: Create a new record (curate) - currently disabled
+    # Second tile: Visual Gallery
+    if "nexuslims_gallery" in installed_apps and getattr(
+        settings, "NX_ENABLE_GALLERY", True
+    ):
+        gallery_tile = {
+            "logo": "fa-images",
+            "link": reverse("nexuslims_gallery_page"),
+            "title": "Visual Gallery",
+            "text": "Explore featured images and datasets from NexusLIMS records",
+            "id": "visual_gallery",
+        }
+        context["tiles"].append(gallery_tile)
+
+    # Third tile: Create a new record (curate) - currently disabled
     if "core_curate_app" in installed_apps:
         curate_tile = {
             "logo": "fa-edit",
@@ -57,7 +70,7 @@ def tiles(request):
         # Uncomment to enable manual record creation:
         # context["tiles"].append(curate_tile)
 
-    # Third tile: Build your own queries - disabled for NexusLIMS
+    # Fourth tile: Build your own queries - disabled for NexusLIMS
     if "core_explore_example_app" in installed_apps:
         explore_example_tile = {
             "logo": "fa-flask",
@@ -69,7 +82,7 @@ def tiles(request):
         # Uncomment to enable:
         # context["tiles"].append(explore_example_tile)
 
-    # Fourth tile: Compose a template - disabled for NexusLIMS
+    # Fifth tile: Compose a template - disabled for NexusLIMS
     if "core_composer_app" in installed_apps:
         compose_tile = {
             "logo": "fa-file-code",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,7 +7,8 @@ from tests.e2e.helpers import fetch_all_records, reset_records
 _USERNAME = "admin"
 _PASSWORD = "admin"
 _BASE_URL = "https://nexuslims-dev.localhost"
-_TIMEOUT_MS = 5_000
+_ACTION_TIMEOUT_MS = 10_000
+_NAVIGATION_TIMEOUT_MS = 15_000
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCREENSHOT_DIR = _REPO_ROOT / "deployment" / "test-results"
@@ -16,8 +17,8 @@ _SCREENSHOT_DIR = _REPO_ROOT / "deployment" / "test-results"
 def new_context(browser, browser_context_args):
     """Create a browser context with project-wide defaults applied."""
     ctx = browser.new_context(**browser_context_args)
-    ctx.set_default_timeout(_TIMEOUT_MS)
-    ctx.set_default_navigation_timeout(_TIMEOUT_MS)
+    ctx.set_default_timeout(_ACTION_TIMEOUT_MS)
+    ctx.set_default_navigation_timeout(_NAVIGATION_TIMEOUT_MS)
     return ctx
 
 
@@ -77,8 +78,8 @@ def auth_state(browser, browser_context_args, base_url):
 def authenticated_page(browser, browser_context_args, auth_state, request):
     """Fresh page pre-loaded with auth session."""
     ctx = browser.new_context(**browser_context_args, storage_state=auth_state)
-    ctx.set_default_timeout(_TIMEOUT_MS)
-    ctx.set_default_navigation_timeout(_TIMEOUT_MS)
+    ctx.set_default_timeout(_ACTION_TIMEOUT_MS)
+    ctx.set_default_navigation_timeout(_NAVIGATION_TIMEOUT_MS)
     page = ctx.new_page()
     yield page
     _screenshot_on_failure(request, page)

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -66,6 +66,24 @@ def test_next_param_redirects_after_login(unauthenticated_page, base_url):
     assert "/annotate/check-auth-only/" in page.url
 
 
+def test_nav_login_redirects_to_current_page(unauthenticated_page, base_url):
+    """Logging in from the navigation returns to the page where login was clicked."""
+    page = unauthenticated_page
+    return_url = f"{base_url}/explore/keyword/?source=login-test"
+    page.goto(return_url)
+    page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
+    page.wait_for_load_state("networkidle")
+    assert "/login" in page.url
+    assert "next=" in page.url
+
+    page.locator("#id_username").fill(_USERNAME)
+    page.locator("#id_password").fill(_PASSWORD)
+    page.locator("[type=submit]").first.click()
+    page.wait_for_load_state("networkidle")
+
+    assert page.url == return_url
+
+
 def test_login_page_redirects_when_already_authenticated(authenticated_page, base_url):
     """Navigating to /login while already logged in redirects away from the login form."""
     page = authenticated_page

--- a/tests/e2e/test_gallery.py
+++ b/tests/e2e/test_gallery.py
@@ -68,13 +68,27 @@ def test_gallery_title_never_exceeds_two_lines(gallery_page):
     assert dimensions["height"] <= dimensions["lineHeight"] * 2 + 1
 
 
-def test_gallery_labels_dataset_description(gallery_page):
-    """The second footer line is identified as a dataset description."""
+def test_gallery_renders_dataset_description_when_present(gallery_page):
+    """The description row reflects whether the selected dataset has a description."""
     gallery_page.wait_for_function(
         "() => document.getElementById('nx-gallery-title').textContent.trim() !== ''"
     )
+    with gallery_page.expect_response(
+        lambda r: "/gallery/api/next/" in r.url, timeout=10_000
+    ) as response_info:
+        gallery_page.keyboard.press("ArrowRight")
+    slide = response_info.value.json()
+    assert "error" not in slide
+
+    description = gallery_page.locator("#nx-gallery-desc")
+    description_text = gallery_page.locator("#nx-gallery-desc-text")
     expect(gallery_page.locator(".nx-gallery-desc-label")).to_have_text("Dataset:")
-    expect(gallery_page.locator("#nx-gallery-desc-text")).not_to_be_empty()
+    if slide.get("description"):
+        expect(description).to_be_visible()
+        expect(description_text).to_have_text(slide["description"])
+    else:
+        expect(description).to_be_hidden()
+        expect(description_text).to_be_empty()
 
 
 def test_right_arrow_key_advances_slide(gallery_page):
@@ -83,7 +97,7 @@ def test_right_arrow_key_advances_slide(gallery_page):
         "() => document.getElementById('nx-gallery-title').textContent.trim() !== ''"
     )
     with gallery_page.expect_response(
-        lambda r: "/gallery/api/next/" in r.url, timeout=5000
+        lambda r: "/gallery/api/next/" in r.url, timeout=10_000
     ) as response_info:
         gallery_page.keyboard.press("ArrowRight")
     slide = response_info.value.json()

--- a/tests/e2e/test_sso.py
+++ b/tests/e2e/test_sso.py
@@ -1,5 +1,4 @@
 """E2E tests for SAML SSO authentication."""
-import pytest
 
 # Dev IdP test credentials -- hardcoded in deployment/dev-sso/authsources.php
 _IDP_USERNAME = "admin"
@@ -91,22 +90,12 @@ def test_sso_logout_clears_session(unauthenticated_page, base_url):
     assert "/login" in page.url or page.locator("#id_username").count() > 0
 
 
-@pytest.mark.xfail(
-    reason=(
-        "CDCS shortcoming: the upstream login template "
-        "core_main_app/templates/core_main_app/user/login/main.html renders the "
-        "SSO button as a static <a href='{% url core_main_app_saml2_login %}'> "
-        "without appending ?next=, so the redirect target is lost on click. "
-        "Fix in nexuslims_overrides/templates/core_main_app/user/login/main.html "
-        "by appending '?next={{ request.GET.next|urlencode }}' to the SSO link "
-        "(and verify the saml2 view forwards it via RelayState)."
-    ),
-    strict=True,
-)
 def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
-    """SSO preserves Django's ?next= param and returns the user to the original URL."""
+    """SSO from the navigation returns to the page where login was clicked."""
     page = unauthenticated_page
-    page.goto(f"{base_url}/annotate/check-auth-only/")
+    return_url = f"{base_url}/explore/keyword/?source=sso-login-test"
+    page.goto(return_url)
+    page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
     page.wait_for_load_state("networkidle")
     assert "/login" in page.url
     assert "next=" in page.url
@@ -118,7 +107,7 @@ def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
     page.locator("[type=submit]").first.click()
     page.wait_for_url(f"{base_url}/**")
 
-    assert "/annotate/check-auth-only/" in page.url
+    assert page.url == return_url
 
 
 def test_sso_admin_user_has_staff_access(unauthenticated_page, base_url):
@@ -128,14 +117,18 @@ def test_sso_admin_user_has_staff_access(unauthenticated_page, base_url):
 
     # Staff users see the 'Administration' link in the user dropdown.
     page.locator("#dropdownDashboard").click()
-    admin_link = page.locator("#dropdownDashboard").locator(
-        "xpath=following-sibling::ul"
-    ).locator("a:has-text('Administration')")
+    admin_link = (
+        page.locator("#dropdownDashboard")
+        .locator("xpath=following-sibling::ul")
+        .locator("a:has-text('Administration')")
+    )
     admin_link.wait_for(state="visible")
     assert admin_link.count() > 0
 
 
-def test_sso_when_already_authenticated_preserves_session(unauthenticated_page, base_url):
+def test_sso_when_already_authenticated_preserves_session(
+    unauthenticated_page, base_url
+):
     """Visiting /login (or re-clicking the SSO button) while authenticated keeps the session."""
     page = unauthenticated_page
     _sso_login(page, base_url)

--- a/tests/test_footer.py
+++ b/tests/test_footer.py
@@ -4,9 +4,38 @@ from importlib.metadata import version
 from pathlib import Path
 
 from django.template import Context, Engine
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
-from nexuslims_overrides.context_processors import nexuslims_settings
+from nexuslims_overrides.context_processors import (
+    nexuslims_features,
+    nexuslims_settings,
+)
+
+
+class FeatureContextTests(SimpleTestCase):
+    @override_settings(
+        INSTALLED_APPS=["nexuslims_gallery"],
+        NX_ENABLE_GALLERY=True,
+    )
+    def test_gallery_enabled_when_app_and_feature_are_enabled(self):
+        context = nexuslims_features(request=None)
+
+        self.assertTrue(context["NX_ENABLE_GALLERY"])
+
+    @override_settings(
+        INSTALLED_APPS=["nexuslims_gallery"],
+        NX_ENABLE_GALLERY=False,
+    )
+    def test_gallery_disabled_by_feature_flag(self):
+        context = nexuslims_features(request=None)
+
+        self.assertFalse(context["NX_ENABLE_GALLERY"])
+
+    @override_settings(INSTALLED_APPS=[], NX_ENABLE_GALLERY=True)
+    def test_gallery_disabled_when_app_is_not_installed(self):
+        context = nexuslims_features(request=None)
+
+        self.assertFalse(context["NX_ENABLE_GALLERY"])
 
 
 class FooterTemplateTests(SimpleTestCase):

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -1,0 +1,26 @@
+"""Tests for NexusLIMS homepage tiles."""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from nexuslims_overrides.views import tiles
+
+
+class HomepageTileTests(SimpleTestCase):
+    @patch("nexuslims_overrides.views.render")
+    def test_gallery_tile_is_included_when_enabled(self, mock_render):
+        tiles(request=None)
+
+        context = mock_render.call_args.args[2]
+        gallery_tile = context["tiles"][0]
+        self.assertEqual(gallery_tile["title"], "Visual Gallery")
+        self.assertEqual(gallery_tile["link"], "/gallery/")
+
+    @override_settings(NX_ENABLE_GALLERY=False)
+    @patch("nexuslims_overrides.views.render")
+    def test_gallery_tile_is_omitted_when_disabled(self, mock_render):
+        tiles(request=None)
+
+        context = mock_render.call_args.args[2]
+        self.assertEqual(context["tiles"], [])


### PR DESCRIPTION
## Summary

This PR fixes the login flow described in #30: selecting **Log In / Sign Up** now preserves the page the user was viewing and returns them there after either local authentication or SAML SSO. Query parameters are retained, so users no longer lose search state or other page context simply because they needed to authenticate.

The same branch also makes the recently added Visual Gallery discoverable without consuming another top-level navigation slot. It introduces an **Explore Data** menu, adds a gallery action and tile to the homepage, teaches the interactive tutorial about the new navigation structure, and expands the public demo landing page to explain the gallery and other core NexusLIMS capabilities.

Closes #30

## Changes

### Login return URLs

- Append the current request path and query string as Django's `next` parameter when an anonymous user selects **Log In / Sign Up**.
- Override the upstream login form template so the SAML SSO link forwards the same `next` value into the SAML flow instead of dropping it.
- Cover both local login and SSO navigation from a record-search URL, including preservation of query parameters.
- Remove the previous expected-failure marker from the SSO redirect test now that the upstream template limitation is handled locally.

### Gallery navigation and homepage discovery

- Replace the standalone **Browse and Search Records** navbar link with a leftmost **Explore Data** dropdown containing:
  - **Browse and Search Records**
  - **Visual Gallery**, when the gallery app and `NX_ENABLE_GALLERY` setting are both enabled
  - <img width="1042" height="350" alt="image" src="https://github.com/user-attachments/assets/c08e82b3-b895-4d9d-b8a8-55949a474ab2" />
- Expose the effective gallery feature flag through the shared template context so disabled or uninstalled deployments do not render dead links.
- Add a feature-gated Visual Gallery homepage tile beside Browse and Search Records, using a responsive 50/50 desktop layout that stacks on smaller screens.
  - <img width="2576" height="1302" alt="image" src="https://github.com/user-attachments/assets/b5fa7c8c-69a1-4196-a193-6312fb5d59fa" />
- Convert the legacy homepage tiles into full-card links with keyboard focus styling and CSS-driven hover states.

### Interactive tutorial

- Open the **Explore Data** dropdown before the desktop tutorial highlights the nested record-search link, then close it before moving to homepage content.
- Add a Visual Gallery tutorial step on desktop and mobile only when the gallery tile exists.
- Clean up Explore and Help dropdown state when a tour completes or is cancelled.

### Public demo presentation

- Add a Visual Gallery hero action using the same primary treatment as **Browse demo records**.
- Replace the crowded demo feature strip with a compact, responsive six-card overview covering automated harvesting, browsing, search, gallery presentation, downloads, and annotation.
- Add scoped typography and spacing for the demo cards so global heading/card styles do not produce oversized or centered copy.
- Refresh the default homepage description to remove obsolete ODI/MML-specific language and describe NexusLIMS in deployment-neutral terms.

### Test reliability and deployment guidance

- Increase Playwright action/assertion timeouts from 5 to 10 seconds and navigation timeouts to 15 seconds for parallel Docker-based runs.
- Make the gallery description test assert against the exact API response that selected the random slide; datasets without descriptions are now correctly expected to hide the description row.
- Clarify how custom gallery logos map from `config/static_files/` into Django's collected static root.
- Update release guidance to use the dedicated XSLT and schema upgrade commands, and remove the stale release changelog fragment.

