### PR TITLE
Harden E2E tests against timing and state races

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -72,12 +72,21 @@ jobs:
           docker exec nexuslims_ci_cdcs \
             python /srv/scripts/init_environment.py
 
-      - name: Run Playwright tests
+      - name: Run parallel Playwright tests
         run: |
           uv run pytest tests/e2e/ \
+            --ignore=tests/e2e/test_annotator_persistence.py \
             --screenshot=only-on-failure \
             --output=deployment/test-results/ \
             -n auto --dist=loadfile \
+            -v
+        working-directory: ${{ github.workspace }}
+
+      - name: Run persistence Playwright tests
+        run: |
+          uv run pytest tests/e2e/test_annotator_persistence.py \
+            --screenshot=only-on-failure \
+            --output=deployment/test-results/ \
             -v
         working-directory: ${{ github.workspace }}
 

--- a/deployment/dev-commands.sh
+++ b/deployment/dev-commands.sh
@@ -77,14 +77,19 @@ alias dev-e2e='_dev_e2e_run'
 alias dev-e2e-headed='_dev_e2e_run --headed --slowmo=500'
 alias dev-e2e-parallel='_dev_e2e_run_parallel'
 
-# Parallel E2E: each test file runs on its own worker; annotator and detail operate on
-# different CDCS records so they can safely run simultaneously.
+# Parallel E2E: non-persistent files run concurrently, then tests that write to
+# the shared annotator record run sequentially.
 _dev_e2e_run_parallel() {
     local paths=("$@")
-    [[ ${#paths[@]} -eq 0 ]] && paths=("tests/e2e/")
     cd "$_DEV_DIR/.." || return 1
     uv run playwright install chromium
-    uv run pytest -v -n auto --dist=loadfile "${paths[@]}"
+    if [[ ${#paths[@]} -eq 0 ]]; then
+        uv run pytest -v -n auto --dist=loadfile \
+            --ignore=tests/e2e/test_annotator_persistence.py tests/e2e/ &&
+            uv run pytest -v tests/e2e/test_annotator_persistence.py
+    else
+        uv run pytest -v -n auto --dist=loadfile "${paths[@]}"
+    fi
 }
 
 # SSO / SimpleSAMLphp helpers

--- a/nexuslims_annotate/templates/nexuslims_annotate/annotate.html
+++ b/nexuslims_annotate/templates/nexuslims_annotate/annotate.html
@@ -325,7 +325,13 @@ function nxOpenSampleModal(sampleId) {
   _nxModalElements = sample ? (sample.elements || []).slice() : [];
   nxRenderElementTags();
 
-  var modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('nx-sample-modal'));
+  var modalEl = document.getElementById('nx-sample-modal');
+  var saveBtn = document.getElementById('nx-sample-modal-save');
+  var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+  saveBtn.disabled = true;
+  modalEl.addEventListener('shown.bs.modal', function() {
+    saveBtn.disabled = false;
+  }, {once: true});
   modal.show();
 }
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,3 +1,4 @@
+import fcntl
 from pathlib import Path
 
 import pytest
@@ -110,7 +111,7 @@ def annotator_page(authenticated_page, base_url, test_record_id):
 
 
 @pytest.fixture(scope="session")
-def _reset_mutable_records(auth_state, base_url):
+def _reset_mutable_records(auth_state, base_url, testrun_uid):
     """Restore example records to their canonical XML before the test session runs.
 
     Annotator tests that save (dataset moves, title edits, sample changes) persist
@@ -122,8 +123,16 @@ def _reset_mutable_records(auth_state, base_url):
     and detail tests). Auth/SSO/gallery/list workers skip this to avoid resetting
     the annotator's working record mid-session during parallel runs.
     """
-    cookies = {c["name"]: c["value"] for c in auth_state["cookies"]}
-    reset_records(cookies, base_url)
+    _SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    marker = _SCREENSHOT_DIR / f".records-reset-{testrun_uid}"
+    with marker.open("a+") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        lock_file.seek(0)
+        if not lock_file.read():
+            cookies = {c["name"]: c["value"] for c in auth_state["cookies"]}
+            reset_records(cookies, base_url)
+            lock_file.write("complete")
+            lock_file.flush()
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,7 @@ import fcntl
 from pathlib import Path
 
 import pytest
+from playwright.sync_api import expect
 
 from tests.e2e.helpers import fetch_all_records, reset_records
 
@@ -105,8 +106,8 @@ def unauthenticated_page(browser, browser_context_args, request):
 def annotator_page(authenticated_page, base_url, test_record_id):
     """Authenticated page pre-navigated to the annotator for the test record."""
     page = authenticated_page
-    page.goto(f"{base_url}/annotate/{test_record_id}/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/annotate/{test_record_id}/", wait_until="domcontentloaded")
+    expect(page.locator("#annotate-save-btn")).to_be_visible()
     return page
 
 

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import requests
+from playwright.sync_api import expect
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -48,15 +49,18 @@ def add_sample(page, name, pid="", description="", elements=()):
     for sym in elements:
         page.locator("#nx-elements-input").fill(sym)
         page.locator("#nx-elements-input").press("Enter")
-    page.locator("#nx-sample-modal-save").click()
-    page.locator("#nx-sample-modal").wait_for(state="hidden")
+    save_btn = page.locator("#nx-sample-modal-save")
+    expect(save_btn).to_be_enabled()
+    save_btn.click()
+    expect(page.locator("#nx-sample-modal")).to_be_hidden()
+    expect(page.locator("#nx-samples-list")).to_contain_text(name)
 
 
 def add_new_activity(page):
     """Click 'Add Activity' and return the seqno of the newly added row."""
     before = page.locator(".nx-sortable-activity").count()
     page.locator("#nx-add-activity-btn").click()
-    page.locator(".nx-sortable-activity").nth(before).wait_for(state="visible")
+    expect(page.locator(".nx-sortable-activity")).to_have_count(before + 1)
     return page.locator(".nx-sortable-activity").last.get_attribute("data-seqno")
 
 

--- a/tests/e2e/test_annotator_activities.py
+++ b/tests/e2e/test_annotator_activities.py
@@ -4,6 +4,8 @@ None of the tests in this module save to CDCS, so they are safe to run in parall
 with other annotator test modules.
 """
 
+from playwright.sync_api import expect
+
 from tests.e2e.helpers import add_sample, add_new_activity
 
 
@@ -15,7 +17,7 @@ class TestActivityManagement:
         page = annotator_page
         before = page.locator(".nx-sortable-activity").count()
         page.locator("#nx-add-activity-btn").click()
-        assert page.locator(".nx-sortable-activity").count() == before + 1
+        expect(page.locator(".nx-sortable-activity")).to_have_count(before + 1)
 
     def test_insert_activity_below(self, annotator_page):
         """Clicking '+ below' on an activity inserts a new row directly after it."""
@@ -25,7 +27,7 @@ class TestActivityManagement:
         )
         before = page.locator(".nx-sortable-activity").count()
         page.locator(".nx-insert-activity-below").first.click()
-        assert page.locator(".nx-sortable-activity").count() == before + 1
+        expect(page.locator(".nx-sortable-activity")).to_have_count(before + 1)
 
     def test_delete_empty_activity(self, annotator_page):
         """Deleting a newly added (empty) activity removes its row from the DOM."""
@@ -33,7 +35,7 @@ class TestActivityManagement:
         before = page.locator(".nx-sortable-activity").count()
         page.locator("#nx-add-activity-btn").click()
         page.locator(".nx-delete-activity:not([disabled])").last.click()
-        assert page.locator(".nx-sortable-activity").count() == before
+        expect(page.locator(".nx-sortable-activity")).to_have_count(before)
 
     def test_delete_button_disabled_when_activity_has_datasets(self, annotator_page):
         """The trash button is disabled for activities that contain datasets."""
@@ -67,7 +69,7 @@ class TestDatasetSelection:
         )
         page.locator(".nx-select-cb").first.click()
         page.locator("#nx-move-toolbar").wait_for(state="visible")
-        assert page.locator("#nx-move-toolbar").is_visible()
+        expect(page.locator("#nx-move-toolbar")).to_be_visible()
 
     def test_selection_count_badge_updates(self, annotator_page):
         """Checking two datasets shows '2' in the selection count badge."""
@@ -79,7 +81,7 @@ class TestDatasetSelection:
         page.locator(".nx-select-cb").nth(1).click()
         count_el = page.locator("#nx-toolbar-sel-count")
         count_el.wait_for(state="visible")
-        assert "2" in count_el.inner_text()
+        expect(count_el).to_contain_text("2")
 
     def test_clear_selection_unchecks_all_datasets(self, annotator_page):
         """Clicking 'Clear selection' unchecks every dataset card."""
@@ -91,7 +93,7 @@ class TestDatasetSelection:
         clear_btn = page.locator("#nx-clear-selection")
         clear_btn.wait_for(state="visible")
         clear_btn.click()
-        assert page.locator(".nx-select-cb:checked").count() == 0
+        expect(page.locator(".nx-select-cb:checked")).to_have_count(0)
 
 
 class TestBatchMove:
@@ -113,13 +115,13 @@ class TestBatchMove:
         page = annotator_page
         new_seqno = self._select_first_and_move_to_new(page)
         target_row = page.locator(f".nx-sortable-activity[data-seqno='{new_seqno}']")
-        assert target_row.locator(".nx-dataset-col").count() > 0
+        expect(target_row.locator(".nx-dataset-col")).not_to_have_count(0)
 
     def test_moved_dataset_shows_moved_badge(self, annotator_page):
         """A dataset that has been moved carries a 'Moved' badge."""
         page = annotator_page
         self._select_first_and_move_to_new(page)
-        assert page.locator(".nx-moved-badge").count() > 0
+        expect(page.locator(".nx-moved-badge")).not_to_have_count(0)
 
     def test_undo_individual_move_via_badge(self, annotator_page):
         """Clicking the 'Moved' badge returns the card to its original activity."""
@@ -133,8 +135,8 @@ class TestBatchMove:
         badge.wait_for(state="visible")
         badge.click()
 
-        assert page.locator(".nx-moved-badge").count() == 0
-        assert orig_row.locator(".nx-dataset-col").count() == orig_count
+        expect(page.locator(".nx-moved-badge")).to_have_count(0)
+        expect(orig_row.locator(".nx-dataset-col")).to_have_count(orig_count)
 
     def test_undo_all_moves_reverts_every_pending_move(self, annotator_page):
         """The 'Undo all moves' button removes all pending-move badges."""
@@ -145,7 +147,7 @@ class TestBatchMove:
         undo_all.wait_for(state="visible")
         undo_all.click()
 
-        assert page.locator(".nx-moved-badge").count() == 0
+        expect(page.locator(".nx-moved-badge")).to_have_count(0)
 
 
 class TestShiftClickSelection:
@@ -159,7 +161,7 @@ class TestShiftClickSelection:
         )
         page.locator(".nx-select-cb").first.click()
         page.locator(".nx-select-cb").nth(2).click(modifiers=["Shift"])
-        assert page.locator(".nx-select-cb:checked").count() == 3
+        expect(page.locator(".nx-select-cb:checked")).to_have_count(3)
 
 
 class TestActivitySampleAssignment:
@@ -175,7 +177,7 @@ class TestActivitySampleAssignment:
         add_sample(page, "Assignment Test")
         page.locator(".nx-activity-sample").first.select_option(label="Assignment Test")
         page.locator("#nx-move-toolbar").wait_for(state="visible")
-        assert page.locator("#nx-move-toolbar").is_visible()
+        expect(page.locator("#nx-move-toolbar")).to_be_visible()
 
     def test_assignment_appears_in_pending_changes_modal(self, annotator_page):
         """Changing an activity's sample appears under 'Sample Assignments' in the modal."""
@@ -281,7 +283,7 @@ class TestCardStatusDot:
             "Canonical annotator record has no dataset textareas"
         )
         page.locator(".annotate-textarea").first.fill("Status dot test content")
-        assert page.locator(".annotate-card[data-status='unsaved']").count() > 0
+        expect(page.locator(".annotate-card[data-status='unsaved']")).not_to_have_count(0)
 
     def test_restoring_original_text_clears_unsaved_status(self, annotator_page):
         """Restoring a textarea to its original value reverts data-status."""
@@ -292,4 +294,6 @@ class TestCardStatusDot:
         ta.fill("Temporary change")
         ta.fill(original)
         expected = "annotated" if original.strip() else "empty"
-        assert page.locator(f".annotate-card[data-status='{expected}']").count() > 0
+        expect(
+            page.locator(f".annotate-card[data-status='{expected}']")
+        ).not_to_have_count(0)

--- a/tests/e2e/test_annotator_general.py
+++ b/tests/e2e/test_annotator_general.py
@@ -4,22 +4,26 @@ None of the tests in this module save to CDCS, so they are safe to run in parall
 with other annotator test modules.
 """
 
+import re
+
+from playwright.sync_api import expect
+
+
 class TestAnnotatorGeneral:
     """Smoke tests and basic interactions that apply to the annotator as a whole."""
 
     def test_annotator_loads(self, annotator_page):
         """Annotator page renders without error."""
         page = annotator_page
-        assert page.locator("#annotate-save-btn").count() > 0
-        assert page.locator("#nx-title-display").count() > 0
+        expect(page.locator("#annotate-save-btn")).to_be_visible()
+        expect(page.locator("#nx-title-display")).to_be_visible()
 
     def test_title_inline_edit(self, annotator_page):
         """Clicking the title edit button opens an inline input."""
         page = annotator_page
         page.locator("#nx-title-edit-btn").click()
         inline_input = page.locator("#nx-title-bar input[type='text']")
-        inline_input.wait_for(state="visible")
-        assert inline_input.is_visible()
+        expect(inline_input).to_be_visible()
 
     def test_title_edit_marks_dirty(self, annotator_page):
         """Changing the title marks the title bar as dirty."""
@@ -29,7 +33,9 @@ class TestAnnotatorGeneral:
         inline_input.wait_for(state="visible")
         inline_input.fill("E2E Test Title Change")
         inline_input.press("Enter")
-        assert page.locator("#nx-title-bar.nx-title-dirty").count() > 0
+        expect(page.locator("#nx-title-bar")).to_have_class(
+            re.compile(r"nx-title-dirty")
+        )
 
     def test_description_textarea_accepts_input(self, annotator_page):
         """Description textareas accept text input."""
@@ -38,15 +44,14 @@ class TestAnnotatorGeneral:
         assert textareas, "Canonical annotator record has no description textareas"
         first_ta = textareas[0]
         first_ta.fill("E2E test description content")
-        assert first_ta.input_value() == "E2E test description content"
+        expect(first_ta).to_have_value("E2E test description content")
 
     def test_add_sample(self, annotator_page):
         """Clicking 'Add Sample' opens the sample modal."""
         page = annotator_page
         page.locator("#nx-add-sample-btn").click()
         modal = page.locator("#nx-sample-modal")
-        modal.wait_for(state="visible")
-        assert modal.is_visible()
+        expect(modal).to_be_visible()
 
     def test_save_sample_from_modal(self, annotator_page):
         """Adding a sample via the modal renders it in the sample list."""
@@ -54,9 +59,11 @@ class TestAnnotatorGeneral:
         page.locator("#nx-add-sample-btn").click()
         page.locator("#nx-sample-modal").wait_for(state="visible")
         page.locator("#nx-sample-name").fill("E2E Test Sample")
-        page.locator("#nx-sample-modal-save").click()
-        page.locator("#nx-sample-modal").wait_for(state="hidden")
-        assert page.locator("#nx-samples-list").inner_text().find("E2E Test Sample") >= 0
+        save_btn = page.locator("#nx-sample-modal-save")
+        expect(save_btn).to_be_enabled()
+        save_btn.click()
+        expect(page.locator("#nx-sample-modal")).to_be_hidden()
+        expect(page.locator("#nx-samples-list")).to_contain_text("E2E Test Sample")
 
     def test_pending_changes_modal_on_navigation(self, annotator_page):
         """Making a change reveals #nx-view-changes-btn which opens the pending-changes modal."""
@@ -71,8 +78,7 @@ class TestAnnotatorGeneral:
         view_changes_btn.wait_for(state="visible")
         view_changes_btn.click()
         modal = page.locator("#nx-pending-changes-modal")
-        modal.wait_for(state="visible")
-        assert modal.is_visible()
+        expect(modal).to_be_visible()
 
 
 class TestTitleEditBehavior:
@@ -89,8 +95,10 @@ class TestTitleEditBehavior:
         inp.press("Escape")
         inp.wait_for(state="hidden")
 
-        assert page.locator("#nx-title-bar.nx-title-dirty").count() == 0
-        assert page.locator("#nx-title-display").inner_text() == original
+        expect(page.locator("#nx-title-bar")).not_to_have_class(
+            re.compile(r"nx-title-dirty")
+        )
+        expect(page.locator("#nx-title-display")).to_have_text(original)
 
     def test_blur_commits_edit_and_marks_dirty(self, annotator_page):
         """Clicking away from the title input saves the new value and marks dirty."""
@@ -102,8 +110,10 @@ class TestTitleEditBehavior:
         page.locator("body").click()
         inp.wait_for(state="hidden")
 
-        assert page.locator("#nx-title-display").inner_text() == "Blur Committed Title"
-        assert page.locator("#nx-title-bar.nx-title-dirty").count() > 0
+        expect(page.locator("#nx-title-display")).to_have_text("Blur Committed Title")
+        expect(page.locator("#nx-title-bar")).to_have_class(
+            re.compile(r"nx-title-dirty")
+        )
 
 
 class TestKeyboardAndToolbar:
@@ -113,15 +123,14 @@ class TestKeyboardAndToolbar:
         """Clicking the '?' button opens the help modal."""
         page = annotator_page
         page.locator("button[data-bs-target='#annotate-help-modal']").click()
-        page.locator("#annotate-help-modal").wait_for(state="visible")
-        assert page.locator("#annotate-help-modal").is_visible()
+        expect(page.locator("#annotate-help-modal")).to_be_visible()
 
     def test_cancel_navigates_to_detail_page(self, annotator_page, test_record_id):
         """Clicking Cancel navigates to the record detail page."""
         page = annotator_page
         page.locator("a.btn.btn-outline-secondary:has-text('Cancel')").click()
         page.wait_for_load_state("networkidle")
-        assert f"id={test_record_id}" in page.url
+        expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
 
 
 class TestErrorBanners:
@@ -132,4 +141,4 @@ class TestErrorBanners:
         page = annotator_page
         page.goto(f"{base_url}/annotate/{test_record_id}/?error=1")
         page.wait_for_load_state("networkidle")
-        assert page.locator(".alert-danger").count() > 0
+        expect(page.locator(".alert-danger")).to_be_visible()

--- a/tests/e2e/test_annotator_general.py
+++ b/tests/e2e/test_annotator_general.py
@@ -129,7 +129,6 @@ class TestKeyboardAndToolbar:
         """Clicking Cancel navigates to the record detail page."""
         page = annotator_page
         page.locator("a.btn.btn-outline-secondary:has-text('Cancel')").click()
-        page.wait_for_load_state("networkidle")
         expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
 
 
@@ -139,6 +138,8 @@ class TestErrorBanners:
     def test_error_query_param_shows_danger_alert(self, annotator_page, base_url, test_record_id):
         """Navigating to the annotator with ?error=1 renders the error alert."""
         page = annotator_page
-        page.goto(f"{base_url}/annotate/{test_record_id}/?error=1")
-        page.wait_for_load_state("networkidle")
+        page.goto(
+            f"{base_url}/annotate/{test_record_id}/?error=1",
+            wait_until="domcontentloaded",
+        )
         expect(page.locator(".alert-danger")).to_be_visible()

--- a/tests/e2e/test_annotator_persistence.py
+++ b/tests/e2e/test_annotator_persistence.py
@@ -7,6 +7,9 @@ modules run in parallel.
 """
 
 import datetime
+import re
+
+from playwright.sync_api import expect
 
 from tests.e2e.helpers import add_sample, add_new_activity
 
@@ -25,12 +28,12 @@ class TestPersistence:
         inline_input.fill(new_title)
         inline_input.press("Enter")
 
-        page.locator("#annotate-save-btn").click()
-        page.wait_for_load_state("networkidle")
+        with page.expect_navigation():
+            page.locator("#annotate-save-btn").click()
 
-        assert f"id={test_record_id}" in page.url
+        expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
         title_el = page.locator(".list-record-title.page-header")
-        assert new_title in title_el.inner_text()
+        expect(title_el).to_contain_text(new_title)
 
     def test_ctrl_enter_submits_form(self, annotator_page, base_url, test_record_id):
         """Pressing Ctrl+Enter saves the form and redirects to the detail page."""
@@ -42,8 +45,8 @@ class TestPersistence:
         inp.press("Enter")
         with page.expect_navigation():
             page.keyboard.press("Control+Enter")
-        assert f"id={test_record_id}" in page.url
-        assert "Ctrl Enter Save" in page.locator(".list-record-title").inner_text()
+        expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
+        expect(page.locator(".list-record-title")).to_contain_text("Ctrl Enter Save")
 
     def test_toolbar_save_button_submits_form(self, annotator_page, base_url, test_record_id):
         """Clicking the toolbar's Save button submits the form."""
@@ -56,8 +59,10 @@ class TestPersistence:
         page.locator("#nx-toolbar-save-btn").wait_for(state="visible")
         with page.expect_navigation():
             page.locator("#nx-toolbar-save-btn").click()
-        assert f"id={test_record_id}" in page.url
-        assert "Toolbar Save Button" in page.locator(".list-record-title").inner_text()
+        expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
+        expect(page.locator(".list-record-title")).to_contain_text(
+            "Toolbar Save Button"
+        )
 
     def test_saved_sample_appears_on_reload(self, annotator_page, base_url, test_record_id):
         """A sample added and saved is still present when the annotator reloads."""
@@ -65,12 +70,12 @@ class TestPersistence:
         unique = datetime.datetime.now().strftime("%H%M%S%f")
         name = f"Persist-{unique}"
         add_sample(page, name)
-        page.locator("#annotate-save-btn").click()
-        page.wait_for_load_state("networkidle")
+        with page.expect_navigation():
+            page.locator("#annotate-save-btn").click()
 
         page.goto(f"{base_url}/annotate/{test_record_id}/")
         page.wait_for_load_state("networkidle")
-        assert name in page.locator("#nx-samples-list").inner_text()
+        expect(page.locator("#nx-samples-list")).to_contain_text(name)
 
     def test_save_with_pending_move_succeeds(self, annotator_page, base_url, test_record_id):
         """Saving with a pending move redirects to the detail page without an error."""
@@ -87,14 +92,14 @@ class TestPersistence:
         page.locator("#nx-move-dropdown-btn").click()
         page.locator(f"#nx-move-dropdown [data-seqno='{new_seqno}']").click()
 
-        page.locator("#annotate-save-btn").click()
-        page.wait_for_load_state("networkidle")
+        with page.expect_navigation():
+            page.locator("#annotate-save-btn").click()
 
-        assert f"id={test_record_id}" in page.url
+        expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
         assert "error" not in page.url
 
         page.goto(f"{base_url}/annotate/{test_record_id}/")
         page.wait_for_load_state("networkidle")
         expect_count = activity_count + 1
-        assert page.locator(".nx-sortable-activity").count() == expect_count
-        assert moved_name in page.locator(".nx-sortable-activity").last.inner_text()
+        expect(page.locator(".nx-sortable-activity")).to_have_count(expect_count)
+        expect(page.locator(".nx-sortable-activity").last).to_contain_text(moved_name)

--- a/tests/e2e/test_annotator_persistence.py
+++ b/tests/e2e/test_annotator_persistence.py
@@ -73,8 +73,9 @@ class TestPersistence:
         with page.expect_navigation():
             page.locator("#annotate-save-btn").click()
 
-        page.goto(f"{base_url}/annotate/{test_record_id}/")
-        page.wait_for_load_state("networkidle")
+        page.goto(
+            f"{base_url}/annotate/{test_record_id}/", wait_until="domcontentloaded"
+        )
         expect(page.locator("#nx-samples-list")).to_contain_text(name)
 
     def test_save_with_pending_move_succeeds(self, annotator_page, base_url, test_record_id):
@@ -98,8 +99,9 @@ class TestPersistence:
         expect(page).to_have_url(re.compile(rf"[?&]id={test_record_id}(?:&|$)"))
         assert "error" not in page.url
 
-        page.goto(f"{base_url}/annotate/{test_record_id}/")
-        page.wait_for_load_state("networkidle")
+        page.goto(
+            f"{base_url}/annotate/{test_record_id}/", wait_until="domcontentloaded"
+        )
         expect_count = activity_count + 1
         expect(page.locator(".nx-sortable-activity")).to_have_count(expect_count)
         expect(page.locator(".nx-sortable-activity").last).to_contain_text(moved_name)

--- a/tests/e2e/test_annotator_samples.py
+++ b/tests/e2e/test_annotator_samples.py
@@ -4,6 +4,10 @@ None of the tests in this module save to CDCS, so they are safe to run in parall
 with other annotator test modules.
 """
 
+import re
+
+from playwright.sync_api import expect
+
 from tests.e2e.helpers import add_sample
 
 
@@ -20,8 +24,8 @@ class TestSampleEditing:
         ).click()
         page.locator("#nx-sample-modal").wait_for(state="visible")
 
-        assert page.locator("#nx-sample-modal-title").inner_text() == "Edit Sample"
-        assert page.locator("#nx-sample-name").input_value() == "Original Name"
+        expect(page.locator("#nx-sample-modal-title")).to_have_text("Edit Sample")
+        expect(page.locator("#nx-sample-name")).to_have_value("Original Name")
 
     def test_edit_updates_name_in_list(self, annotator_page):
         """Saving an edited sample reflects the new name in the samples list."""
@@ -33,12 +37,12 @@ class TestSampleEditing:
         ).click()
         page.locator("#nx-sample-modal").wait_for(state="visible")
         page.locator("#nx-sample-name").fill("After Edit")
-        page.locator("#nx-sample-modal-save").click()
-        page.locator("#nx-sample-modal").wait_for(state="hidden")
-
-        list_text = page.locator("#nx-samples-list").inner_text()
-        assert "After Edit" in list_text
-        assert "Before Edit" not in list_text
+        save_btn = page.locator("#nx-sample-modal-save")
+        expect(save_btn).to_be_enabled()
+        save_btn.click()
+        expect(page.locator("#nx-sample-modal")).to_be_hidden()
+        expect(page.locator("#nx-samples-list")).to_contain_text("After Edit")
+        expect(page.locator("#nx-samples-list")).not_to_contain_text("Before Edit")
 
 
 class TestSampleDeletion:
@@ -48,12 +52,12 @@ class TestSampleDeletion:
         """Deleting an unassigned sample removes it from the list without a dialog."""
         page = annotator_page
         add_sample(page, "Delete Me")
-        assert "Delete Me" in page.locator("#nx-samples-list").inner_text()
+        expect(page.locator("#nx-samples-list")).to_contain_text("Delete Me")
 
         page.locator("#nx-samples-list > div").filter(has_text="Delete Me").locator(
             "button[title='Delete sample']"
         ).click()
-        assert "Delete Me" not in page.locator("#nx-samples-list").inner_text()
+        expect(page.locator("#nx-samples-list")).not_to_contain_text("Delete Me")
 
     def test_delete_assigned_sample_shows_confirm_dialog(self, annotator_page):
         """Deleting a sample that is assigned to an activity triggers a confirm dialog."""
@@ -87,7 +91,7 @@ class TestSampleDeletion:
             "button[title='Delete sample']"
         ).click()
         page.locator("#nx-samples-list").wait_for()
-        assert "Keep Me" in page.locator("#nx-samples-list").inner_text()
+        expect(page.locator("#nx-samples-list")).to_contain_text("Keep Me")
 
 
 class TestSampleValidation:
@@ -100,7 +104,9 @@ class TestSampleValidation:
         page.locator("#nx-sample-modal").wait_for(state="visible")
         page.locator("#nx-sample-name").fill("")
         page.locator("#nx-sample-modal-save").click()
-        assert page.locator("#nx-sample-name.is-invalid").count() > 0
+        expect(page.locator("#nx-sample-name")).to_have_class(
+            re.compile(r"is-invalid")
+        )
 
     def test_empty_name_keeps_modal_open(self, annotator_page):
         """Saving without a name does not dismiss the modal."""
@@ -109,7 +115,7 @@ class TestSampleValidation:
         page.locator("#nx-sample-modal").wait_for(state="visible")
         page.locator("#nx-sample-name").fill("")
         page.locator("#nx-sample-modal-save").click()
-        assert page.locator("#nx-sample-modal").is_visible()
+        expect(page.locator("#nx-sample-modal")).to_be_visible()
 
 
 class TestSamplePID:
@@ -119,18 +125,20 @@ class TestSamplePID:
         """An https:// PID renders as an <a> element with the correct href."""
         page = annotator_page
         add_sample(page, "PID Sample", pid="https://doi.org/10.1234/sample")
-        assert (
-            page.locator("#nx-samples-list a[href='https://doi.org/10.1234/sample']").count() > 0
-        )
+        expect(
+            page.locator(
+                "#nx-samples-list a[href='https://doi.org/10.1234/sample']"
+            )
+        ).to_be_visible()
 
     def test_non_url_pid_renders_as_plain_text(self, annotator_page):
         """A PID without an http scheme renders as text (no anchor element)."""
         page = annotator_page
         add_sample(page, "Plain PID Sample", pid="ark:/99999/fk4test")
-        assert "ark:/99999/fk4test" in page.locator("#nx-samples-list").inner_text()
-        assert (
-            page.locator("#nx-samples-list a[href='ark:/99999/fk4test']").count() == 0
-        )
+        expect(page.locator("#nx-samples-list")).to_contain_text("ark:/99999/fk4test")
+        expect(
+            page.locator("#nx-samples-list a[href='ark:/99999/fk4test']")
+        ).to_have_count(0)
 
 
 class TestSampleElements:
@@ -143,8 +151,8 @@ class TestSampleElements:
         page.locator("#nx-sample-modal").wait_for(state="visible")
         page.locator("#nx-elements-input").fill("Fe")
         page.locator("#nx-elements-input").press("Enter")
-        assert page.locator("#nx-elements-tags .badge").count() > 0
-        assert "Fe" in page.locator("#nx-elements-tags").inner_text()
+        expect(page.locator("#nx-elements-tags .badge")).to_have_count(1)
+        expect(page.locator("#nx-elements-tags")).to_contain_text("Fe")
 
     def test_remove_element_via_x_button(self, annotator_page):
         """Clicking × on an element badge removes it from the tag list."""
@@ -154,12 +162,11 @@ class TestSampleElements:
         page.locator("#nx-elements-input").fill("Au")
         page.locator("#nx-elements-input").press("Enter")
         page.locator("#nx-elements-tags .badge button").first.click()
-        assert "Au" not in page.locator("#nx-elements-tags").inner_text()
+        expect(page.locator("#nx-elements-tags")).not_to_contain_text("Au")
 
     def test_elements_appear_as_chips_in_sample_list(self, annotator_page):
         """Elements saved with a sample appear as code chips in the sample list."""
         page = annotator_page
         add_sample(page, "Alloy Sample", elements=["Ni", "Cr"])
-        list_text = page.locator("#nx-samples-list").inner_text()
-        assert "Ni" in list_text
-        assert "Cr" in list_text
+        expect(page.locator("#nx-samples-list")).to_contain_text("Ni")
+        expect(page.locator("#nx-samples-list")).to_contain_text("Cr")

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,5 +1,7 @@
 """E2E tests for username/password authentication."""
 
+from playwright.sync_api import expect
+
 _USERNAME = "admin"
 _PASSWORD = "admin"
 
@@ -38,14 +40,13 @@ def test_logout_clears_session(unauthenticated_page, base_url):
     # Logout is inside the #dropdownDashboard Bootstrap menu — open it first.
     page.locator("#dropdownDashboard").click()
     page.locator("a[href*='logout'].cdcs-menu-item").wait_for(state="visible")
-    page.locator("a[href*='logout'].cdcs-menu-item").click()
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation():
+        page.locator("a[href*='logout'].cdcs-menu-item").click()
 
     # Confirm the session is gone: a protected page should redirect to login.
     if "/login" not in page.url and page.locator("#id_username").count() == 0:
         page.goto(f"{base_url}/annotate/check-auth-only/")
-        page.wait_for_load_state("networkidle")
-    assert "/login" in page.url or page.locator("#id_username").count() > 0
+    expect(page.locator("#id_username")).to_be_visible()
 
 
 def test_next_param_redirects_after_login(unauthenticated_page, base_url):
@@ -53,14 +54,13 @@ def test_next_param_redirects_after_login(unauthenticated_page, base_url):
     page = unauthenticated_page
     # Hit a @login_required view unauthenticated; Django appends ?next=...
     page.goto(f"{base_url}/annotate/check-auth-only/")
-    page.wait_for_load_state("networkidle")
     assert "/login" in page.url
     assert "next=" in page.url
 
     page.locator("#id_username").fill(_USERNAME)
     page.locator("#id_password").fill(_PASSWORD)
     page.locator("[type=submit]").first.click()
-    page.wait_for_load_state("networkidle")
+    page.wait_for_url("**/annotate/check-auth-only/")
 
     # Should land at /annotate/check-auth-only/, not the default post-login page.
     assert "/annotate/check-auth-only/" in page.url
@@ -72,16 +72,14 @@ def test_nav_login_redirects_to_current_page(unauthenticated_page, base_url):
     return_url = f"{base_url}/explore/keyword/?source=login-test"
     page.goto(return_url)
     page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
-    page.wait_for_load_state("networkidle")
+    page.wait_for_url("**/login?next=*")
     assert "/login" in page.url
     assert "next=" in page.url
 
     page.locator("#id_username").fill(_USERNAME)
     page.locator("#id_password").fill(_PASSWORD)
     page.locator("[type=submit]").first.click()
-    page.wait_for_load_state("networkidle")
-
-    assert page.url == return_url
+    expect(page).to_have_url(return_url)
 
 
 def test_login_page_redirects_when_already_authenticated(authenticated_page, base_url):

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,5 +1,7 @@
 """E2E tests for username/password authentication."""
 
+import re
+
 from playwright.sync_api import expect
 
 _USERNAME = "admin"
@@ -72,9 +74,8 @@ def test_nav_login_redirects_to_current_page(unauthenticated_page, base_url):
     return_url = f"{base_url}/explore/keyword/?source=login-test"
     page.goto(return_url)
     page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
-    page.wait_for_url("**/login?next=*")
-    assert "/login" in page.url
-    assert "next=" in page.url
+    expect(page).to_have_url(re.compile(r"/login\?next="))
+    expect(page.locator("#id_username")).to_be_visible()
 
     page.locator("#id_username").fill(_USERNAME)
     page.locator("#id_password").fill(_PASSWORD)

--- a/tests/e2e/test_curation.py
+++ b/tests/e2e/test_curation.py
@@ -308,10 +308,9 @@ def test_editor_hover_preview_fill(
     _hover_row(page, 4)
     circle = _circle(page, 4, 5)
     expect(circle).to_be_visible()
-    circle.hover()
+    circle.dispatch_event("mouseover")
     expect(_filled(page, 4)).to_have_count(5)
-    # Move mouse away from the rating group to trigger its mouseleave
-    page.mouse.move(0, 0)
+    _group(page, 4).dispatch_event("mouseleave")
     expect(_filled(page, 4)).to_have_count(0)
 
 

--- a/tests/e2e/test_curation.py
+++ b/tests/e2e/test_curation.py
@@ -44,8 +44,8 @@ def reset_curation(auth_state, base_url, curation_record_id):
 
 
 def _go(page, base_url, record_id):
-    page.goto(f"{base_url}/data?id={record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/data?id={record_id}", wait_until="domcontentloaded")
+    expect(page.locator(".nx-name-row")).not_to_have_count(0)
 
 
 def _name_row(page, idx):
@@ -375,8 +375,7 @@ def test_rating_persists_after_reload(
     _hover_row(page, 4)
     _click_circle(page, 4, 4)
     expect(_group(page, 4)).to_have_attribute("data-current-rating", "4")
-    page.reload()
-    page.wait_for_load_state("networkidle")
+    page.reload(wait_until="domcontentloaded")
     expect(_filled(page, 4)).to_have_count(4)
     expect(_group(page, 4)).to_have_attribute("data-current-rating", "4")
 
@@ -390,8 +389,7 @@ def test_featured_persists_after_reload(
     _hover_row(page, 3)
     _click_star(page, 3)
     expect(_star(page, 3)).to_have_class(re.compile(r"nx-star--featured"))
-    page.reload()
-    page.wait_for_load_state("networkidle")
+    page.reload(wait_until="domcontentloaded")
     expect(_star(page, 3)).to_have_class(re.compile(r"nx-star--featured"))
 
 
@@ -404,8 +402,7 @@ def test_clear_rating_persists_after_reload(
     _hover_row(page, 0)
     _click_clear(page, 0)
     expect(_group(page, 0)).to_have_attribute("data-current-rating", "0")
-    page.reload()
-    page.wait_for_load_state("networkidle")
+    page.reload(wait_until="domcontentloaded")
     expect(_filled(page, 0)).to_have_count(0)
     expect(_group(page, 0)).to_have_attribute("data-current-rating", "0")
 
@@ -419,6 +416,5 @@ def test_unfeature_persists_after_reload(
     _hover_row(page, 0)
     _click_star(page, 0)
     expect(_star(page, 0)).not_to_have_class(re.compile(r"nx-star--featured"))
-    page.reload()
-    page.wait_for_load_state("networkidle")
+    page.reload(wait_until="domcontentloaded")
     expect(_star(page, 0)).not_to_have_class(re.compile(r"nx-star--featured"))

--- a/tests/e2e/test_curation.py
+++ b/tests/e2e/test_curation.py
@@ -291,7 +291,9 @@ def test_editor_hover_preview_fill(
     page = authenticated_page
     _go(page, base_url, curation_record_id)
     _hover_row(page, 4)
-    _circle(page, 4, 5).hover(force=True)
+    circle = _circle(page, 4, 5)
+    expect(circle).to_be_visible()
+    circle.hover()
     expect(_filled(page, 4)).to_have_count(5)
     # Move mouse away from the rating group to trigger its mouseleave
     page.mouse.move(0, 0)

--- a/tests/e2e/test_curation.py
+++ b/tests/e2e/test_curation.py
@@ -76,8 +76,13 @@ def _star(page, idx):
 
 
 def _click_star(page, idx):
-    """Click a star already revealed by the parent row hover."""
-    _star(page, idx).click(force=True)
+    """Dispatch a star click and wait for the feature request to succeed."""
+    star = _star(page, idx)
+    expect(star).to_be_visible()
+    with page.expect_response(lambda response: response.url.endswith("/feature/")) as info:
+        star.dispatch_event("click")
+    assert info.value.ok
+    assert info.value.json()["ok"]
 
 
 def _group(page, idx):
@@ -94,8 +99,13 @@ def _circle(page, idx, value):
 
 
 def _click_circle(page, idx, value):
-    """Click a rating circle already revealed by the parent row hover."""
-    _circle(page, idx, value).click(force=True)
+    """Dispatch a circle click and wait for the rating request to succeed."""
+    circle = _circle(page, idx, value)
+    expect(circle).to_be_visible()
+    with page.expect_response(lambda response: response.url.endswith("/rate/")) as info:
+        circle.dispatch_event("click")
+    assert info.value.ok
+    assert info.value.json()["ok"]
 
 
 def _clear(page, idx):
@@ -103,8 +113,13 @@ def _clear(page, idx):
 
 
 def _click_clear(page, idx):
-    """Click a clear button already revealed by the parent row hover."""
-    _clear(page, idx).click(force=True)
+    """Dispatch a clear click and wait for the rating request to succeed."""
+    clear = _clear(page, idx)
+    expect(clear).to_be_visible()
+    with page.expect_response(lambda response: response.url.endswith("/rate/")) as info:
+        clear.dispatch_event("click")
+    assert info.value.ok
+    assert info.value.json()["ok"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_gallery.py
+++ b/tests/e2e/test_gallery.py
@@ -1,5 +1,7 @@
 """E2E tests for the nexuslims_gallery jumbotron page."""
 
+import re
+
 import pytest
 from playwright.sync_api import expect
 
@@ -122,6 +124,5 @@ def test_view_record_link_opens_record(gallery_page):
     with gallery_page.expect_popup() as popup_info:
         gallery_page.locator("#nx-gallery-link").click()
     detail_page = popup_info.value
-    detail_page.wait_for_load_state("networkidle")
-    assert "/data?id=" in detail_page.url
+    expect(detail_page).to_have_url(re.compile(r"/data\?id="))
     expect(detail_page.locator(".list-record-title")).not_to_be_empty()

--- a/tests/e2e/test_record_detail.py
+++ b/tests/e2e/test_record_detail.py
@@ -6,8 +6,9 @@ from playwright.sync_api import expect
 def test_detail_page_loads(authenticated_page, base_url, normal_record_id):
     """Detail page renders without error for a known record."""
     page = authenticated_page
-    response = page.goto(f"{base_url}/data?id={normal_record_id}")
-    page.wait_for_load_state("networkidle")
+    response = page.goto(
+        f"{base_url}/data?id={normal_record_id}", wait_until="domcontentloaded"
+    )
     assert response.status == 200
     expect(page.locator(".list-record-title")).to_be_visible()
 
@@ -15,8 +16,9 @@ def test_detail_page_loads(authenticated_page, base_url, normal_record_id):
 def test_detail_shows_key_fields(authenticated_page, base_url, normal_record_id):
     """Key metadata fields are visible on the rendered detail page."""
     page = authenticated_page
-    page.goto(f"{base_url}/data?id={normal_record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{base_url}/data?id={normal_record_id}", wait_until="domcontentloaded"
+    )
     expect(page.locator(".list-record-title")).not_to_be_empty()
     expect(page.locator("#instr-badge")).not_to_be_empty()
     expect(page.locator(".list-record-experimenter")).not_to_be_empty()
@@ -26,8 +28,9 @@ def test_detail_shows_key_fields(authenticated_page, base_url, normal_record_id)
 def test_annotate_button_navigates(authenticated_page, base_url, normal_record_id):
     """'Annotate Record' button on the detail page opens the full-page annotator."""
     page = authenticated_page
-    page.goto(f"{base_url}/data?id={normal_record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{base_url}/data?id={normal_record_id}", wait_until="domcontentloaded"
+    )
 
     annotate_btn = page.locator("#annotate-record-btn")
     annotate_btn.wait_for(state="visible")
@@ -42,8 +45,9 @@ def test_annotate_button_navigates(authenticated_page, base_url, normal_record_i
 def test_detail_shows_expected_normal_content(authenticated_page, base_url, normal_record_id):
     """Normal record's XSLT output contains title, instrument, motivation, and counts."""
     page = authenticated_page
-    page.goto(f"{base_url}/data?id={normal_record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{base_url}/data?id={normal_record_id}", wait_until="domcontentloaded"
+    )
 
     expect(page.locator(".list-record-title")).to_contain_text(
         "Test record with a multi-dataset file"
@@ -64,8 +68,10 @@ def test_simple_display_record_renders_warning(
 ):
     """Large record triggers the simple display wrapper class and warning alert."""
     page = authenticated_page
-    page.goto(f"{base_url}/data?id={simple_display_record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{base_url}/data?id={simple_display_record_id}",
+        wait_until="domcontentloaded",
+    )
 
     assert page.locator(".simple-display").count() > 0, (
         "Expected .simple-display wrapper class on a 200-dataset record"
@@ -82,8 +88,10 @@ def test_simple_display_shows_expected_content(
 ):
     """Simple-display record's XSLT output contains title, instrument, motivation, and counts."""
     page = authenticated_page
-    page.goto(f"{base_url}/data?id={simple_display_record_id}")
-    page.wait_for_load_state("networkidle")
+    page.goto(
+        f"{base_url}/data?id={simple_display_record_id}",
+        wait_until="domcontentloaded",
+    )
 
     expect(page.locator(".list-record-title")).to_contain_text(
         "Test record to trigger simple display"

--- a/tests/e2e/test_record_list.py
+++ b/tests/e2e/test_record_list.py
@@ -12,16 +12,14 @@ def test_record_list_renders(unauthenticated_page, base_url):
     workspace, so no login is needed to see them on the list page.
     """
     page = unauthenticated_page
-    page.goto(f"{base_url}/explore/keyword/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/explore/keyword/", wait_until="domcontentloaded")
     expect(page.locator("a[href*='/data?id=']")).not_to_have_count(0)
 
 
 def test_search_filters_records(authenticated_page, base_url):
     """Typing in the search box filters the record list."""
     page = authenticated_page
-    page.goto(f"{base_url}/explore/keyword/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/explore/keyword/", wait_until="domcontentloaded")
 
     record_links = "a[href*='/data?id=']"
     expect(page.locator(record_links)).not_to_have_count(0)
@@ -32,7 +30,6 @@ def test_search_filters_records(authenticated_page, base_url):
     keyword_input.fill("zzznomatch")
     keyword_input.press("Enter")
     page.locator("button:has-text('Search')").click()
-    page.wait_for_load_state("networkidle")
 
     expect(page.locator(record_links)).to_have_count(0)
     expect(page.get_by_text("No results found")).to_be_visible()
@@ -45,8 +42,7 @@ def test_keyword_search_returns_matching_record(unauthenticated_page, base_url):
     triggers the simple display), so the search narrows the list to that one.
     """
     page = unauthenticated_page
-    page.goto(f"{base_url}/explore/keyword/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/explore/keyword/", wait_until="domcontentloaded")
 
     record_links = page.locator("a[href*='/data?id=']")
     expect(record_links).not_to_have_count(0)
@@ -69,32 +65,34 @@ def test_instrument_badge_filters_records(unauthenticated_page, base_url):
     that each filter reduces the count and that TEM has more records than STEM.
     """
     page = unauthenticated_page
-    page.goto(f"{base_url}/explore/keyword/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/explore/keyword/", wait_until="domcontentloaded")
 
     record_links = page.locator("a[href*='/data?id=']")
+    expect(record_links).not_to_have_count(0)
     total = record_links.count()
     assert total >= 3
 
     # Filter to the FEI Titan TEM instrument.
-    page.locator(
-        "span.instrument-badge-clickable[data-instrument-pid='FEI-Titan-TEM']"
-    ).first.click()
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation():
+        page.locator(
+            "span.instrument-badge-clickable[data-instrument-pid='FEI-Titan-TEM']"
+        ).first.click()
+    expect(record_links).not_to_have_count(0)
     tem_count = record_links.count()
     assert tem_count >= 1
 
     # Clear the filter and restore the full list.
     page.locator(".tagit-choice .tagit-close").first.click()
-    page.locator("button:has-text('Search')").click()
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation():
+        page.locator("button:has-text('Search')").click()
     expect(record_links).to_have_count(total)
 
     # Filter to the FEI Titan STEM instrument.
-    page.locator(
-        "span.instrument-badge-clickable[data-instrument-pid='FEI-Titan-STEM']"
-    ).first.click()
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation():
+        page.locator(
+            "span.instrument-badge-clickable[data-instrument-pid='FEI-Titan-STEM']"
+        ).first.click()
+    expect(record_links).not_to_have_count(0)
     stem_count = record_links.count()
     assert stem_count >= 1
     assert stem_count < total
@@ -104,11 +102,9 @@ def test_instrument_badge_filters_records(unauthenticated_page, base_url):
 def test_record_link_navigates_to_detail(authenticated_page, base_url):
     """Clicking a record link navigates to the detail page."""
     page = authenticated_page
-    page.goto(f"{base_url}/explore/keyword/")
-    page.wait_for_load_state("networkidle")
+    page.goto(f"{base_url}/explore/keyword/", wait_until="domcontentloaded")
 
     first_link = page.locator("a[href*='/data?id=']").first
     first_link.click()
-    page.wait_for_load_state("networkidle")
     expect(page).to_have_url(re.compile(r"/data\?id="))
     expect(page.locator(".list-record-title")).to_be_visible()

--- a/tests/e2e/test_record_list.py
+++ b/tests/e2e/test_record_list.py
@@ -1,5 +1,7 @@
 """E2E tests for the record list and search."""
 
+import re
+
 from playwright.sync_api import expect
 
 
@@ -12,8 +14,7 @@ def test_record_list_renders(unauthenticated_page, base_url):
     page = unauthenticated_page
     page.goto(f"{base_url}/explore/keyword/")
     page.wait_for_load_state("networkidle")
-    records = page.locator("a[href*='/data?id=']").all()
-    assert len(records) > 0, "No record links found on the list page"
+    expect(page.locator("a[href*='/data?id=']")).not_to_have_count(0)
 
 
 def test_search_filters_records(authenticated_page, base_url):
@@ -23,7 +24,7 @@ def test_search_filters_records(authenticated_page, base_url):
     page.wait_for_load_state("networkidle")
 
     record_links = "a[href*='/data?id=']"
-    assert page.locator(record_links).count() > 0
+    expect(page.locator(record_links)).not_to_have_count(0)
 
     # The keyword field is a jQuery Tag-it widget: the real input is hidden and
     # the visible field registers a tag on Enter before the search is submitted.
@@ -33,8 +34,7 @@ def test_search_filters_records(authenticated_page, base_url):
     page.locator("button:has-text('Search')").click()
     page.wait_for_load_state("networkidle")
 
-    filtered_count = page.locator(record_links).count()
-    assert filtered_count == 0
+    expect(page.locator(record_links)).to_have_count(0)
     expect(page.get_by_text("No results found")).to_be_visible()
 
 
@@ -49,7 +49,7 @@ def test_keyword_search_returns_matching_record(unauthenticated_page, base_url):
     page.wait_for_load_state("networkidle")
 
     record_links = page.locator("a[href*='/data?id=']")
-    assert record_links.count() >= 3
+    expect(record_links).not_to_have_count(0)
 
     # The keyword field is a jQuery Tag-it widget: the real input is hidden and
     # the visible field registers a tag on Enter before the search is submitted.
@@ -88,7 +88,7 @@ def test_instrument_badge_filters_records(unauthenticated_page, base_url):
     page.locator(".tagit-choice .tagit-close").first.click()
     page.locator("button:has-text('Search')").click()
     page.wait_for_load_state("networkidle")
-    assert record_links.count() == total
+    expect(record_links).to_have_count(total)
 
     # Filter to the FEI Titan STEM instrument.
     page.locator(
@@ -110,5 +110,5 @@ def test_record_link_navigates_to_detail(authenticated_page, base_url):
     first_link = page.locator("a[href*='/data?id=']").first
     first_link.click()
     page.wait_for_load_state("networkidle")
-    assert "/data?id=" in page.url
+    expect(page).to_have_url(re.compile(r"/data\?id="))
     expect(page.locator(".list-record-title")).to_be_visible()

--- a/tests/e2e/test_sso.py
+++ b/tests/e2e/test_sso.py
@@ -1,5 +1,7 @@
 """E2E tests for SAML SSO authentication."""
 
+import re
+
 from playwright.sync_api import expect
 
 # Dev IdP test credentials -- hardcoded in deployment/dev-sso/authsources.php
@@ -97,9 +99,8 @@ def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
     return_url = f"{base_url}/explore/keyword/?source=sso-login-test"
     page.goto(return_url)
     page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
-    page.wait_for_url("**/login?next=*")
-    assert "/login" in page.url
-    assert "next=" in page.url
+    expect(page).to_have_url(re.compile(r"/login\?next="))
+    expect(page.locator("#id_username")).to_be_visible()
 
     page.locator("a.btn-lge, a[href*='saml2/login']").first.click()
     expect(page.locator("input[name='username']")).to_be_visible()
@@ -108,7 +109,7 @@ def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
     page.locator("[type=submit]").first.click()
     page.wait_for_url(f"{base_url}/**")
 
-    assert page.url == return_url
+    expect(page).to_have_url(return_url)
 
 
 def test_sso_admin_user_has_staff_access(unauthenticated_page, base_url):

--- a/tests/e2e/test_sso.py
+++ b/tests/e2e/test_sso.py
@@ -1,5 +1,7 @@
 """E2E tests for SAML SSO authentication."""
 
+from playwright.sync_api import expect
+
 # Dev IdP test credentials -- hardcoded in deployment/dev-sso/authsources.php
 _IDP_USERNAME = "admin"
 _IDP_PASSWORD = "admin"
@@ -9,7 +11,7 @@ def _sso_login(page, base_url, username=_IDP_USERNAME, password=_IDP_PASSWORD):
     """Walk through the full SSO flow starting from /login. Caller owns the page."""
     page.goto(f"{base_url}/login")
     page.locator("a.btn-lge, a[href*='saml2/login']").first.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
     page.locator("input[name='username']").fill(username)
     page.locator("input[name='password']").fill(password)
     page.locator("[type=submit]").first.click()
@@ -22,7 +24,7 @@ def test_sso_login_redirects_to_idp(unauthenticated_page, base_url):
     page.goto(f"{base_url}/login")
     sso_btn = page.locator("a.btn-lge, a[href*='saml2/login']").first
     sso_btn.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
     assert "sso.nexuslims-dev.localhost" in page.url or "saml" in page.url.lower()
 
 
@@ -32,7 +34,7 @@ def test_sso_login_full_flow(unauthenticated_page, base_url):
     page.goto(f"{base_url}/login")
     sso_btn = page.locator("a.btn-lge, a[href*='saml2/login']").first
     sso_btn.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
 
     page.locator("input[name='username']").fill(_IDP_USERNAME)
     page.locator("input[name='password']").fill(_IDP_PASSWORD)
@@ -62,11 +64,11 @@ def test_sso_invalid_credentials_stays_on_idp(unauthenticated_page, base_url):
     page = unauthenticated_page
     page.goto(f"{base_url}/login")
     page.locator("a.btn-lge, a[href*='saml2/login']").first.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
     page.locator("input[name='username']").fill(_IDP_USERNAME)
     page.locator("input[name='password']").fill("definitely-wrong-password")
     page.locator("[type=submit]").first.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
     # Should still be on the IdP host, not redirected back to the CDCS app.
     assert "sso.nexuslims-dev.localhost" in page.url
     assert "/login" not in page.url or "sso.nexuslims-dev.localhost" in page.url
@@ -80,14 +82,13 @@ def test_sso_logout_clears_session(unauthenticated_page, base_url):
     # Logout via the user dropdown.
     page.locator("#dropdownDashboard").click()
     page.locator("a[href*='logout'].cdcs-menu-item").wait_for(state="visible")
-    page.locator("a[href*='logout'].cdcs-menu-item").click()
-    page.wait_for_load_state("networkidle")
+    with page.expect_navigation():
+        page.locator("a[href*='logout'].cdcs-menu-item").click()
 
     # Visiting a @login_required page should now bounce back to login.
     if "/login" not in page.url and page.locator("#id_username").count() == 0:
         page.goto(f"{base_url}/annotate/check-auth-only/")
-        page.wait_for_load_state("networkidle")
-    assert "/login" in page.url or page.locator("#id_username").count() > 0
+    expect(page.locator("#id_username")).to_be_visible()
 
 
 def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
@@ -96,12 +97,12 @@ def test_sso_next_param_redirects_after_login(unauthenticated_page, base_url):
     return_url = f"{base_url}/explore/keyword/?source=sso-login-test"
     page.goto(return_url)
     page.locator("a.btn-custom", has_text="Log In / Sign Up").click()
-    page.wait_for_load_state("networkidle")
+    page.wait_for_url("**/login?next=*")
     assert "/login" in page.url
     assert "next=" in page.url
 
     page.locator("a.btn-lge, a[href*='saml2/login']").first.click()
-    page.wait_for_load_state("networkidle")
+    expect(page.locator("input[name='username']")).to_be_visible()
     page.locator("input[name='username']").fill(_IDP_USERNAME)
     page.locator("input[name='password']").fill(_IDP_PASSWORD)
     page.locator("[type=submit]").first.click()


### PR DESCRIPTION
## Summary

The Playwright suite contained several independent sources of intermittent CI failures:

- Tests used `networkidle` as a generic readiness signal even though application pages can perform background requests indefinitely or under variable CI load.
- Curation controls exist only while their table row is hovered, so Playwright actionability retries could make the target disappear.
- Curation mutations were not synchronized directly with their API responses.
- The sample modal allowed Save during Bootstrap's opening transition, when `hide()` requests are ignored.
- Session-scoped record resets ran once per xdist worker, causing concurrent PATCH requests against the same records.
- Persistence tests wrote to the same annotator record while non-persistent modules opened fresh pages from it.
- Several tests used immediate DOM assertions rather than Playwright's retrying expectations.

This PR addresses each race directly without increasing timeouts or adding sleeps.

## Changes

### Page readiness

- Remove every `networkidle` wait from the E2E suite.
- Use `domcontentloaded` only as the navigation baseline.
- Wait for page-specific UI such as annotator controls, record rows, titles, login fields, IdP fields, search results, URLs, or explicit navigation events.
- Synchronize asynchronous search result rendering separately from form navigation.

### Curation interactions

- Test transient rating preview by dispatching the handler's `mouseover` and `mouseleave` events after separately verifying the control is visible.
- Synchronize star, rating, and clear mutations with their matching API responses and assert successful HTTP and JSON results.

### Sample modal

- Disable Save while the modal is opening.
- Enable Save on `shown.bs.modal`, preventing submission while Bootstrap is transitioning.
- Shared sample helpers wait for Save to be enabled, modal dismissal, and the rendered sample.

### Parallel test isolation

- Protect the initial canonical-record reset with a cross-worker file lock and per-run marker.
- Run 104 non-persistent tests in parallel.
- Run 5 database-writing annotator persistence tests sequentially afterward.
- Update `dev-e2e-parallel` to match CI.

### Retrying assertions

- Replace timing-sensitive immediate DOM checks with Playwright `expect` assertions.
- Synchronize form submissions with navigation events.

## Testing

Earlier comprehensive verification:

- Focused changed modules in parallel: 72 passed
- Parallel non-persistent suite: 104 passed
- Sequential persistence suite: 5 passed
- Immediate parallel rerun after persistence mutations: 104 passed

Readiness-change validation:

- Targeted annotator fixture, curation hover, auth logout, SSO logout, and record filtering checks passed
- Test collection: 109 tests
- No `networkidle` waits remain
- Python compile check: passed
- Diff whitespace and line-length checks: passed

Per request, the full suite was not repeatedly rerun locally because these failures reproduce only under CI load.

## Risks And Deployment

Low runtime risk. Production behavior changes only by disabling sample Save during the existing modal fade-in animation. CI scheduling changes preserve full coverage while removing concurrent writes to shared test records. No migrations or deployment configuration changes are required.